### PR TITLE
Adopt cpp netlib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,18 +34,20 @@ AS_IF([test "$enable_cpp_netlib" != "no"],
        AC_SUBST(openssl_LIBS)
        AC_SUBST(openssl_CFLAGS)
 
+       AC_DEFINE(BOOST_NETWORK_ENABLE_HTTPS, [], [With HTTPS support])
+
        dnl cpp-netlib installs itself within the boost directory by default.
        dnl so we presume this is where we'll find it, the AC_CHECK_HEADER below
        dnl does the check. TODO This needs a proper solution.
        AX_BOOST_BASE([1.58], [:], [AC_MSG_ERROR([cpp-netlib requires boost, but not found.])])
        CPP_NETLIB_CPPFLAGS="$BOOST_CPPFLAGS $BOOST_CPPFLAGS/boost"
-       CPP_NETLIB_LDFLAGS="$BOOST_LDFLAGS $BOOST_LDFLAGS/boost"
+       CPP_NETLIB_LDFLAGS="$BOOST_LDFLAGS $BOOST_LDFLAGS/boost -lcppnetlib-client-connections -lcppnetlib-uri -lcppnetlib-server-parsers"
        AC_SUBST(CPP_NETLIB_CPPFLAGS)
        AC_SUBST(CPP_NETLIB_LDFLAGS)
        ])
 
 SAVE_CPPFLAGS="${CPPFLAGS}"
-CPPFLAGS="${CPPFLAGS} ${CPP_NETLIB_CPPFLAGS}"
+CPPFLAGS="${CPPFLAGS} ${CPP_NETLIB_CPPFLAGS} ${openssl_CFLAGS}"
 
 AS_IF([test "$enable_cpp_netlib" != "no"],
       [AC_CHECK_HEADER(network/protocol.hpp,

--- a/src/c++11/Makefile.am
+++ b/src/c++11/Makefile.am
@@ -1,22 +1,22 @@
 
-lib_LTLIBRARIES = liblightstep_basic_cxx11.la
+lib_LTLIBRARIES = liblightstep_nonetwork_cxx11.la
 
-liblightstep_basic_cxx11_la_SOURCES = \
+liblightstep_nonetwork_cxx11_la_SOURCES = \
 	impl.cc \
 	span.cc \
 	tracer.cc \
 	util.cc \
 	dropbox_json/json11.cpp
 
-liblightstep_basic_cxx11_la_CXXFLAGS = $(AM_CXXFLAGS) -I dropbox_json
-liblightstep_basic_cxx11_la_LIBADD   =
+liblightstep_nonetwork_cxx11_la_CXXFLAGS = $(AM_CXXFLAGS) -I dropbox_json
+liblightstep_nonetwork_cxx11_la_LIBADD   =
 
 if ENABLE_CPP_NETLIB
 liblightstep_cxx11_la_SOURCES = \
 	recorder.cc
 
 liblightstep_cxx11_la_CXXFLAGS = $(AM_CXXFLAGS) $(CPP_NETLIB_CPPFLAGS) -I dropbox_json
-liblightstep_cxx11_la_LIBADD   = liblightstep_basic_cxx11.la $(CPP_NETLIB_LDFLAGS)
+liblightstep_cxx11_la_LIBADD   = liblightstep_nonetwork_cxx11.la $(CPP_NETLIB_LDFLAGS)
 
 lib_LTLIBRARIES += liblightstep_cxx11.la
 

--- a/src/c++11/config.h.in
+++ b/src/c++11/config.h.in
@@ -1,5 +1,8 @@
 /* src/c++11/config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* With HTTPS support */
+#undef BOOST_NETWORK_ENABLE_HTTPS
+
 /* define if the Boost library is available */
 #undef HAVE_BOOST
 

--- a/src/c++11/impl.h
+++ b/src/c++11/impl.h
@@ -20,6 +20,7 @@ namespace lightstep {
 
 typedef std::lock_guard<std::mutex> MutexLock;
 
+class Recorder;
 class SpanImpl;
 struct TracerOptions;
 struct StartSpanOptions;
@@ -67,6 +68,8 @@ class TracerImpl {
     MutexLock lock(mutex_);
     return recorder_;
   }
+
+  void set_recorder(std::unique_ptr<Recorder> recorder);
 
  private:
   void GetTwoIds(uint64_t *a, uint64_t *b);

--- a/src/c++11/options.h
+++ b/src/c++11/options.h
@@ -13,14 +13,12 @@
 namespace lightstep {
 
 class TracerImpl;
-class Recorder;
 
 typedef std::chrono::system_clock Clock;
 typedef Clock::time_point TimeStamp;
+typedef Clock::duration Duration;
 
 typedef std::unordered_map<std::string, std::string> Attributes;
-
-typedef std::function<std::unique_ptr<Recorder>(const TracerImpl& impl)> RecorderFactory;
 
 struct TracerOptions {
   std::string access_token;
@@ -37,11 +35,6 @@ struct TracerOptions {
 
   // Indicates whether to collect this span.
   std::function<bool(uint64_t)> should_sample;
-
-  // The flush / transport implementation.  If 'recorder' is a
-  // nullptr, the default implementation will be supplied using this
-  // options struct to configure the delivery endpoint.
-  RecorderFactory recorder_factory;
 };
 
 struct StartSpanOptions {

--- a/src/c++11/recorder.cc
+++ b/src/c++11/recorder.cc
@@ -1,272 +1,184 @@
+#include <algorithm>
 #include <exception>
 #include <thread>
-#include <iostream>  // TODO Remove in favor of error logging support.
+#include <iostream>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <boost/network/protocol/http/client.hpp>
 
 #include "impl.h"
 #include "recorder.h"
 #include "options.h"
+#include "tracer.h"
 #include "util.h"
 
 namespace lightstep {
 
 using namespace lightstep_net;
 
-const char CollectorThriftRpcPath[] = "/_rpc/v1/reports/binary";
+const char CollectorJsonRpcPath[] = "/_rpc/v1/reports/binary";
 
-const uint64_t MaxSpansPerReport = 2500;
-const uint64_t ReportIntervalMillisecs = 2500;
-const uint32_t ReportSizeLowerBound = 200;
+std::string urlOf(const TracerOptions& options) {
+  std::ostringstream os;
+  os << (options.collector_encryption == "tls" ? "https" : "http") << "://"
+     << options.collector_host << ":" << options.collector_port << CollectorJsonRpcPath;
+  return os.str();
+}
 
-namespace {
+BasicRecorderOptions::BasicRecorderOptions()
+  : time_limit(std::chrono::seconds(1)),
+    size_limit(1<<20) { }
 
-class Initializer {
+class BasicRecorder : public Recorder {
 public:
-  Initializer() {
-    RegisterRecorderFactory([](const TracerImpl& impl) {
-	return NewDefaultRecorder(impl);
-      });
+  BasicRecorder(const TracerImpl& impl, const BasicRecorderOptions& options);
+
+  ~BasicRecorder() {
+    make_writer_exit();
+    writer_.join();
   }
-};
 
-// Registers a factory.
-Initializer initializer;
+  void RecordSpan(lightstep_net::SpanRecord&& span) override {
+    MutexLock lock(write_mutex_);
+    if (encoder_.pendingSize() >= options_.size_limit) {
+      dropped_spans_++;
+      return;
+    }
+    encoder_.recordSpan(std::move(span));
+    if (encoder_.pendingSize() >= options_.size_limit) {
+      write_cond_.notify_all();
+    }
+  }
 
-}  // namespace
+  bool FlushWithTimeout(Duration timeout) override;
 
-namespace transport {
-
-typedef std::lock_guard<std::mutex> MutexLock;
-
-class DefaultRecorder : public Recorder {
-public:
-  DefaultRecorder(const TracerImpl& impl);
-  ~DefaultRecorder();
-
-  void RecordSpan(lightstep_net::SpanRecord&& span) override;
-
-  void Flush() override;
-  
 private:
-  void Write();
-
-  void ProcessResponse(const ReportResponse& response);
+  void write();
+  void write_report(const std::string&);
+  void flush_one();
 
   // Forces the writer thread to exit immediately.
   void make_writer_exit() {
-    MutexLock lock(cond_mutex_);
-    writer_exit_ = true;
-    writer_cond_.notify_one();
+    MutexLock lock(write_mutex_);
+    write_exit_ = true;
+    write_cond_.notify_all();
   }
 
   // Waits until either the timeout or the writer thread is forced to
   // exit.  Returns true if it should continue writing, false if it
   // should exit.
-  bool wait_to_write_until(const std::chrono::steady_clock::time_point &next) {
-    std::unique_lock<std::mutex> lock(cond_mutex_);
-    writer_cond_.wait_until(lock, next, [this]() {
-	return this->writer_exit_;
+  bool wait_for_next_write(const Clock::time_point &next) {
+    std::unique_lock<std::mutex> lock(write_mutex_);
+    write_cond_.wait_until(lock, next, [this]() {
+  	return this->write_exit_ ||
+	       this->encoder_.pendingSize() >= options_.size_limit;
       });
-    return !writer_exit_;
+    return !write_exit_;
   }
     
   const TracerImpl& tracer_;
+  const BasicRecorderOptions options_;
 
-  std::mutex cond_mutex_; // For the writer condition variable
-  std::mutex flush_mutex_; // Prevent simultaneous flushes
-  std::mutex pending_mutex_; // Protect pending_spans
-
-  // Background Flush thread.
+  // Writer state.
+  std::mutex write_mutex_;
+  std::condition_variable write_cond_;
+  bool write_exit_;
   std::thread writer_;
-  std::condition_variable writer_cond_;
-  bool writer_exit_;
 
-  // Vector of spans for the current/last flush.  This is swapped with
-  // pending_spans_ at each flush.
-  std::vector<lightstep_net::SpanRecord> flushing_spans_;
+  // Buffer state (protected by write_mutex_).
+  JsonEncoder encoder_;
+  std::string inflight_;
+  size_t flushed_seqno_;
+  size_t encoding_seqno_;
+  size_t dropped_spans_;
 
-  // Vector of spans for the next flush
-  std::vector<lightstep_net::SpanRecord> pending_spans_;
-
-  // Transport mechanism.
-  // boost::shared_ptr<TSocket> socket_;
-  // boost::shared_ptr<TSSLSocketFactory> ssl_factory_;
-  // boost::shared_ptr<THttpClient> transport_;
+  // Network connection
+  boost::network::http::client client_;
+  // TODO uncertainties around connection request. supposedly connections are
+  // persistent by default, so maybe I can reuse this.
+  boost::network::http::client::request request_;
 };
 
-DefaultRecorder::DefaultRecorder(const TracerImpl& tracer)
+BasicRecorder::BasicRecorder(const TracerImpl& tracer, const BasicRecorderOptions& options)
   : tracer_(tracer),
-    writer_exit_(false) {
-  MutexLock lock(flush_mutex_);
+    options_(options),
+    write_exit_(false),
+    writer_(std::thread(&BasicRecorder::write, this)),
+    encoder_(tracer),
+    flushed_seqno_(0),
+    encoding_seqno_(1),
+    dropped_spans_(0),
+    request_(urlOf(tracer.options())) { }
 
-  writer_ = std::thread(&DefaultRecorder::Write, this);
+void BasicRecorder::write() {
+  auto next = Clock::now() + options_.time_limit;
 
-  std::cerr << "Connecting..." << tracer_.options().collector_host << ":" << tracer_.options().collector_port << CollectorThriftRpcPath;
+  while (wait_for_next_write(next)) {
+    flush_one();
 
-  socket_ = boost::shared_ptr<TSocket>(new TSocket(tracer_.options().collector_host,
-						   tracer_.options().collector_port));
-  boost::shared_ptr<TTransport> trans = socket_;
-
-  if (tracer_.options().collector_encryption == "tls") {
-    initializeOpenSSL();
-    ssl_factory_ = boost::shared_ptr<TSSLSocketFactory>(new TSSLSocketFactory(SSLTLS));
-    trans = ssl_factory_->createSocket(socket_->getSocketFD());
-  }
-
-  // Note: THttpClient buffers the input and output automatically.
-  transport_ = boost::shared_ptr<THttpClient>(new THttpClient(trans, tracer_.options().collector_host, CollectorThriftRpcPath));
-
-  try {
-    transport_->open();
-  } catch (std::exception &e) {
-    std::cerr << "Connect error: " << e.what() << std::endl;
-  }
-}
-
-DefaultRecorder::~DefaultRecorder() {
-  make_writer_exit();
-  writer_.join();
-}
-
-void DefaultRecorder::RecordSpan(lightstep_net::SpanRecord&& span) {
-  MutexLock lock(pending_mutex_);
-  if (pending_spans_.size() < MaxSpansPerReport) {
-    pending_spans_.emplace_back(std::move(span));
-  } else {
-    // TODO Count dropped span.
-  }
-}
-
-void DefaultRecorder::Write() {
-  using namespace std::chrono;
-  auto interval = milliseconds(ReportIntervalMillisecs);
-  auto next = steady_clock::now() + interval;
-
-  while (wait_to_write_until(next)) {
-    Flush();
-
-    auto end = steady_clock::now();
+    auto end = Clock::now();
     auto elapsed = end - next;
 
-    if (elapsed > interval) {
+    if (elapsed > options_.time_limit) {
       next = end;
     } else {
-      next = end + interval - elapsed;
-    }    
+      next = end + options_.time_limit - elapsed;
+    }
   }
 }
 
-void DefaultRecorder::Flush() {
-  MutexLock lock(flush_mutex_);
+void BasicRecorder::flush_one() {
+  size_t seq;
   {
-    MutexLock lock(pending_mutex_);
-
-    // Note: At present, there cannot be another Flush call
-    // outstanding because the Flush API is not exposed.  More
-    // synchronization will be needed if flushing_spans_ is pending in
-    // another Flush operation.
-    if (!flushing_spans_.empty()) {
-      throw std::runtime_error("Invalid flushing_spans_ state");
-    }
-    std::swap(flushing_spans_, pending_spans_);
-
-    if (flushing_spans_.empty()) return;
+    // Swap the pending encoder with the inflight encoder, then use
+    // inflight without a lock. Assumption is that this thread is the
+    // only place inflight_ is used.
+    MutexLock lock(write_mutex_);
+    std::swap(encoder_.jsonString(), inflight_);
+    ++encoding_seqno_;
   }
-
-  EncodeForTransit(tracer_, flushing_spans_, [this](const uint8_t* buffer, uint32_t length) {
-      try {
-	if (!transport_->isOpen()) {
-	  transport_->open();
-	}
-	transport_->write(buffer, length);
-	transport_->flush();
-
-	// Note: Use Thrift directly here to read a response because
-	// it's difficult to know how much to read without making
-	// assumptions about the underlying transport.
-	//
-	// Recommend for "DIY" transport to ignore the response and
-	// simply drain the response channel.  We will abandon Thrift
-	// for transport in favor of gRPC, after which this topic will
-	// be revisited.
-	boost::shared_ptr<TBinaryProtocol> proto(new TBinaryProtocol(transport_));
-	ReportingServiceClient client(proto);
-
-	ReportResponse response;
-	client.recv_Report(response);
-	ProcessResponse(response);
-      } catch (std::exception &e) {
-	std::cerr << "Write error: " << e.what() << std::endl;
-      }	
-    });
+  write_report(inflight_);
+  {
+    MutexLock lock(write_mutex_);
+    ++flushed_seqno_;
+  }  
 }
 
-void DefaultRecorder::ProcessResponse(const ReportResponse& response) {
-  // TODO Implement clock synchronization.  (Though we think that if
-  // this code is running on a machine with NTP, shouldn't be
-  // necessary.)
-  //
-  // TODO Implement Disable command ("Big Red Button") support.
-  for (const auto& error : response.errors) {
-    if (error.empty()) continue;
-    // TODO Use proper logging.
-    std::cerr << "Controller error: " << error;
-    if (error[error.size()-1] != '\n') {
-      std::cerr << std::endl;
-    }
-  }
+void BasicRecorder::write_report(const std::string& report) {
+  boost::network::http::client::response response = client_.get(request_);
+  std::cout << body(response) << std::endl;
 }
 
-} // namespace transport
+bool BasicRecorder::FlushWithTimeout(Duration timeout) {
+  // Note: there is no effort made to speed up the flush when
+  // requested, it simply waits for the regularly scheduled flush
+  // operations to clear out all the presently pending data.
+  std::unique_lock<std::mutex> lock(write_mutex_);
 
-std::unique_ptr<Recorder> NewDefaultRecorder(const TracerImpl& impl) {
-  return std::unique_ptr<Recorder>(new transport::DefaultRecorder(impl));
+  bool has_encoded = encoder_.pendingSize() != 0;
+
+  if (!has_encoded && encoding_seqno_ == 1 + flushed_seqno_) {
+    return true;
+  }
+
+  size_t wait_seq = encoding_seqno_ + (has_encoded ? 1 : 0);
+
+  return write_cond_.wait_for(lock, timeout, [this, wait_seq]() {
+    return this->flushed_seqno_ >= wait_seq;
+  });
 }
 
-void Recorder::EncodeForTransit(const TracerImpl& tracer,
-				std::vector<lightstep_net::SpanRecord>& spans,
-				std::function<void(const uint8_t* bytes, uint32_t len)> func) {
-
-  // TODO Use a more accurate size upper-bound.
-  uint32_t size_est = ReportSizeLowerBound * spans.size();
-  boost::shared_ptr<TMemoryBuffer> memory(new TMemoryBuffer(size_est));
-  boost::shared_ptr<TBinaryProtocol> proto(new TBinaryProtocol(memory));
-
-  ReportRequest report;
-
-  // Note: the following construction happens once per report but
-  // is static information, could be precomputed.
-  Runtime runtime;
-  runtime.__set_guid(tracer.runtime_guid());
-  runtime.__set_start_micros(tracer.runtime_start_micros());
-  runtime.__set_group_name(tracer.component_name());
-  std::vector<KeyValue> attrs;
-  for (auto it = tracer.runtime_attributes().begin();
-       it != tracer.runtime_attributes().end(); ++it) {
-    attrs.emplace_back(util::make_kv(it->first, it->second));
-  }
-  runtime.attrs = std::move(attrs);
-  runtime.__isset.attrs = true;
-  report.runtime = std::move(runtime);
-  report.__isset.runtime = true;
-
-  // Swap the flushing spans into report, serialize, swap back, then
-  // clear.  This allows re-use of the spans memory.
-  std::swap(report.span_records, spans);
-  report.__isset.span_records = true;
-
-  lightstep_net::ReportingServiceClient client(proto);
-  lightstep_net::Auth auth;
-  auth.__set_access_token(tracer.access_token());
-  client.send_Report(auth, report);
-
-  std::swap(report.span_records, spans);
-  spans.clear();
-
-  uint8_t *buffer;
-  uint32_t length;
-  memory->getBuffer(&buffer, &length);
-
-  func(buffer, length);
+Tracer NewLightStepTracer(const TracerOptions& topts,
+			  const BasicRecorderOptions& bopts) {
+  ImplPtr impl(new TracerImpl(topts));
+  impl->set_recorder(std::unique_ptr<Recorder>(new BasicRecorder(*impl, bopts)));
+  return Tracer(impl);
 }
 
 }  // namespace lightstep

--- a/src/c++11/recorder.h
+++ b/src/c++11/recorder.h
@@ -2,27 +2,24 @@
 #ifndef __LIGHTSTEP_RECORDER_H__
 #define __LIGHTSTEP_RECORDER_H__
 
-// TODO This class does not compile--fix. Presently this code can only
-// be built with configure --disable-cpp-netlib.
-
 // Defines the Recorder interface which supports encoding and
 // transporting LightStep requests to the collector.
 
-#include <mutex>
-#include <utility>
-#include <vector>
-
-namespace lightstep_net {
-class SpanRecord;
-}  // namespace lightstep_net
+#include "tracer.h"
 
 namespace lightstep {
 
-class TracerImpl;
+// To setup user-defined transport, configure BasicRecorderOptions.
+class BasicRecorderOptions {
+public:
+  BasicRecorderOptions();
 
-// NewDefaultRecorder returns a Recorder implementation that writes to
-// LightStep using a background thread that flushes periodically.
-std::unique_ptr<Recorder> NewDefaultRecorder(const TracerImpl &impl);
+  Duration   time_limit; // Default is 1s
+  size_t     size_limit; // Default is 1Mb
+};
+
+Tracer NewLightStepTracer(const TracerOptions& topts,
+			  const BasicRecorderOptions& bopts);
 
 }  // namespace lightstep
 

--- a/src/c++11/tracer.cc
+++ b/src/c++11/tracer.cc
@@ -44,129 +44,105 @@ Span Tracer::StartSpanWithOptions(const StartSpanOptions& options) const {
   return Span(impl_->StartSpan(impl_, options));
 }
 
-Tracer NewTracer(const TracerOptions& options) {
-  ImplPtr impl(new TracerImpl(options));
-  return Tracer(impl);
+JsonEncoder::JsonEncoder(const TracerImpl& tracer)
+  : tracer_(tracer) {
+  setJsonPrefix();
 }
 
-UserDefinedTransportOptions::UserDefinedTransportOptions() {
-  this->callback = [](const std::string& report) {
-    std::cerr << report << std::endl;
-  };
-}
-
-class UserDefinedRecorder : public Recorder {
-public:
-  UserDefinedRecorder(const TracerImpl& tracer, const UserDefinedTransportOptions& options)
-    : tracer_(tracer),
-      options_(options) {
-    setJsonPrefix();
-  }
-
-  virtual void RecordSpan(lightstep_net::SpanRecord&& span) {
-    MutexLock lock(mutex_);
-    Json::object s;
-    s["span_guid"] = Json(span.span_guid);
-    s["trace_guid"] = Json(span.trace_guid);
-    s["runtime_guid"] = Json(span.runtime_guid);
-    s["span_name"] = Json(span.span_name);
-    s["oldest_micros"] = Json(double(span.oldest_micros));
-    s["youngest_micros"] = Json(double(span.youngest_micros));
-    s["error_flag"] = Json(span.error_flag);
-    if (span.join_ids.empty()) {
-      s["join_ids"] = traceJoinArray(span.join_ids);
-    }
-    if (!span.attributes.empty()) {
-      s["attributes"] = keyValueArray(span.attributes);
-    }
-
-    if (assembled_++ != 0) {
-      assembly_.append(", ");
-    }
-    Json(s).dump(assembly_);
-  }
-
-  virtual void Flush() {
-    MutexLock lock(mutex_);
-    assembly_.append(" ] }");
-    addJsonSuffix();
-    options_.callback(assembly_);
-    setJsonPrefix();
-  }
-  
-private:
-  Json keyValueArray(const std::vector<KeyValue>& v) {
-    Json::array a;
-    for (const auto& x : v) {
-      Json::object p;
-      p["Key"] = Json(x.Key);
-      p["Value"] = Json(x.Value);
-      a.emplace_back(Json(p));
-    }
-    return Json(a);
-  }
-  Json keyValueArray(const std::unordered_map<std::string, std::string>& v) {
-    Json::array a;
-    for (const auto& x : v) {
-      Json::object p;
-      p["Key"] = Json(x.first);
-      p["Value"] = Json(x.second);
-      a.emplace_back(Json(p));
-    }
-    return Json(a);
-  }
-  Json traceJoinArray(const std::vector<TraceJoinId>& v) {
-    Json::array a;
-    for (const auto& x : v) {
-      Json::object p;
-      p["TraceKey"] = Json(x.TraceKey);
-      p["Value"] = Json(x.Value);
-      a.emplace_back(Json(p));
-    }
-    return Json(a);
-  }
-  
-  void setJsonPrefix() {
-    assembly_.clear();
-    assembly_.append("{ ");
-    addReportFields();
-    assembly_.append(", \"span_records\": [ ");
+void JsonEncoder::recordSpan(lightstep_net::SpanRecord&& span) {
+  if (assembled_ < 0) {
     assembled_ = 0;
+    setJsonPrefix();
+  }
+  Json::object s;
+  s["span_guid"] = Json(span.span_guid);
+  s["trace_guid"] = Json(span.trace_guid);
+  s["runtime_guid"] = Json(span.runtime_guid);
+  s["span_name"] = Json(span.span_name);
+  s["oldest_micros"] = Json(double(span.oldest_micros));
+  s["youngest_micros"] = Json(double(span.youngest_micros));
+  s["error_flag"] = Json(span.error_flag);
+  if (span.join_ids.empty()) {
+    s["join_ids"] = traceJoinArray(span.join_ids);
+  }
+  if (!span.attributes.empty()) {
+    s["attributes"] = keyValueArray(span.attributes);
+  }
+  MutexLock lock(mutex_);
+  if (assembled_++ != 0) {
+    assembly_.append(", ");
+  }
+  Json(s).dump(assembly_);
+}
+
+std::string& JsonEncoder::jsonString() {
+  if (assembled_ >= 0) {
+    addJsonSuffix();
+    assembled_ = -1;
+  }
+  return assembly_;
+}
+  
+Json JsonEncoder::keyValueArray(const std::vector<KeyValue>& v) {
+  Json::array a;
+  for (const auto& x : v) {
+    Json::object p;
+    p["Key"] = Json(x.Key);
+    p["Value"] = Json(x.Value);
+    a.emplace_back(Json(p));
+  }
+  return Json(a);
+}
+Json JsonEncoder::keyValueArray(const std::unordered_map<std::string, std::string>& v) {
+  Json::array a;
+  for (const auto& x : v) {
+    Json::object p;
+    p["Key"] = Json(x.first);
+    p["Value"] = Json(x.second);
+    a.emplace_back(Json(p));
+  }
+  return Json(a);
+}
+Json JsonEncoder::traceJoinArray(const std::vector<TraceJoinId>& v) {
+  Json::array a;
+  for (const auto& x : v) {
+    Json::object p;
+    p["TraceKey"] = Json(x.TraceKey);
+    p["Value"] = Json(x.Value);
+    a.emplace_back(Json(p));
+  }
+  return Json(a);
+}
+  
+void JsonEncoder::setJsonPrefix() {
+  assembled_ = 0;
+  assembly_.clear();
+  assembly_.append("{ ");
+  addReportFields();
+  assembly_.append(", \"span_records\": [ ");
+}
+
+void JsonEncoder::addReportFields() {
+  Json::object r;
+  r["guid"] = Json(tracer_.runtime_guid());
+  r["start_micros"] = Json(double(tracer_.runtime_start_micros()));
+  r["group_name"] = Json(tracer_.component_name());
+  if (!tracer_.runtime_attributes().empty()) {
+    r["attrs"] = keyValueArray(tracer_.runtime_attributes());
   }
 
-  void addReportFields() {
-    Json::object r;
-    r["guid"] = Json(tracer_.runtime_guid());
-    r["start_micros"] = Json(double(tracer_.runtime_start_micros()));
-    r["group_name"] = Json(tracer_.component_name());
-    if (!tracer_.runtime_attributes().empty()) {
-      r["attrs"] = keyValueArray(tracer_.runtime_attributes());
-    }
+  assembly_.append("\"runtime\": ");
+  Json(r).dump(assembly_);
 
-    assembly_.append("\"runtime\": ");
-    Json(r).dump(assembly_);
+  // TODO Add more "oldest_micros", "youngest_micros",
+  // "timestamp_offset_micros", "log_records", "internal_logs",
+  // "internal_metrics".
+}
 
-    // TODO Add more "oldest_micros", "youngest_micros",
-    // "timestamp_offset_micros", "log_records", "internal_logs",
-    // "internal_metrics".
-  }
-
-  void addJsonSuffix() {
-    // assembly_ contains { "runtime": ..., ..., "span_records": [ ...
-    // now close the span_records array and report request object:
-    assembly_.append("] }");
-  }
-
-  const TracerImpl& tracer_;
-  const UserDefinedTransportOptions options_;
-
-  std::mutex mutex_;
-  std::string assembly_;
-  int assembled_;
-};
-
-std::unique_ptr<Recorder> NewUserDefinedTransport(const TracerImpl& tracer, const UserDefinedTransportOptions& options) {
-  return std::unique_ptr<Recorder>(new UserDefinedRecorder(tracer, options));
+void JsonEncoder::addJsonSuffix() {
+  // assembly_ contains { "runtime": ..., ..., "span_records": [ ...
+  // now close the span_records array and report request object:
+  assembly_.append("] }");
 }
 
 }  // namespace lightstep

--- a/src/c++11/tracer.cc
+++ b/src/c++11/tracer.cc
@@ -76,7 +76,9 @@ void JsonEncoder::recordSpan(lightstep_net::SpanRecord&& span) {
 }
 
 std::string& JsonEncoder::jsonString() {
-  if (assembled_ >= 0) {
+  if (assembled_ < 0) {
+    assembly_.clear();
+  } else {
     addJsonSuffix();
     assembled_ = -1;
   }

--- a/src/c++11/tracer.h
+++ b/src/c++11/tracer.h
@@ -68,7 +68,11 @@ public:
 
   // Flush with an indefinite timeout.
   virtual void Flush() {
-    FlushWithTimeout(Duration::max());
+    // N.B.: Do not use Duration::max() it will overflow the internals
+    // of std::condition_variable::wait_for, for example.
+    FlushWithTimeout(std::chrono::hours(24));
+    // TODO and panic when it fails? use absolute time instead, to
+    // avoid the overflow issue?
   }
 };
 

--- a/test/c++11/Makefile.am
+++ b/test/c++11/Makefile.am
@@ -2,7 +2,7 @@ noinst_PROGRAMS = tracer_test
 
 tracer_test_SOURCES = tracer_test.cc
 tracer_test_CXXFLAGS = -I ../../src/c++11
-tracer_test_LDADD = ../../src/c++11/liblightstep_basic_cxx11.la
+tracer_test_LDADD = ../../src/c++11/liblightstep_cxx11.la
 
 if ENABLE_CPP_NETLIB
 noinst_PROGRAMS += cppclient

--- a/test/c++11/cppclient.cc
+++ b/test/c++11/cppclient.cc
@@ -3,8 +3,9 @@
 #include <thread>
 #include <chrono>
 
-#include "tracer.h"
 #include "impl.h"
+#include "recorder.h"
+#include "tracer.h"
 
 #include "dropbox_json/json11.hpp"
 #include "zintinio_happyhttp/happyhttp.h"
@@ -28,7 +29,8 @@ lightstep::Tracer NewTracer() {
   topts.collector_host = hostName;
   topts.collector_port = hostPort;
   topts.collector_encryption = "none";
-  return lightstep::NewTracer(topts);
+  lightstep::BasicRecorderOptions bopts;
+  return lightstep::NewLightStepTracer(topts, bopts);
 }
 
 double to_seconds(lightstep::TimeStamp::duration d) {

--- a/test/c++11/tracer_test.cc
+++ b/test/c++11/tracer_test.cc
@@ -2,8 +2,9 @@
 #include <chrono>
 #include <thread>
 
-#include "tracer.h"
 #include "impl.h"
+#include "recorder.h"
+#include "tracer.h"
 
 using namespace lightstep;
 
@@ -23,18 +24,14 @@ int main() {
     span.Finish();
 
     TracerOptions topts;
-    // TODO these are not used b/c user-defined transport below.
-    // topts.access_token = "bfcebc4e1fa7e66d5502a4af87ae854f";
-    // topts.collector_host = "collector.lightstep.com";
-    // topts.collector_port = 9997;
-    // topts.collector_encryption = "tls";
+    topts.access_token = "bfcebc4e1fa7e66d5502a4af87ae854f";
+    topts.collector_host = "collector.lightstep.com";
+    topts.collector_port = 9997;
+    topts.collector_encryption = "tls";
 
-    topts.recorder_factory = [](const TracerImpl& tracer) {
-      UserDefinedTransportOptions tropts;
-      return lightstep::NewUserDefinedTransport(tracer, tropts);
-    };
+    BasicRecorderOptions bopts;
 
-    Tracer::InitGlobal(NewTracer(topts));
+    Tracer::InitGlobal(NewLightStepTracer(topts, bopts));
 
     for (int i = 0; i < 10; i++) {
       span = Tracer::Global().StartSpanWithOptions(sopts);

--- a/test/c++11/tracer_test.cc
+++ b/test/c++11/tracer_test.cc
@@ -26,8 +26,15 @@ int main() {
     TracerOptions topts;
     topts.access_token = "bfcebc4e1fa7e66d5502a4af87ae854f";
     topts.collector_host = "collector.lightstep.com";
-    topts.collector_port = 9997;
-    topts.collector_encryption = "tls";
+    // topts.collector_port = 9997;
+    // topts.collector_encryption = "tls";
+    topts.collector_port = 9998;
+    topts.collector_encryption = "";
+
+    // topts.access_token = "DEVELOPMENT_TOKEN_spoons";
+    // topts.collector_host = "localhost";
+    // topts.collector_port = 9998;
+    // topts.collector_encryption = "";
 
     BasicRecorderOptions bopts;
 
@@ -42,6 +49,8 @@ int main() {
     Tracer::Global().impl()->Flush();
   } catch (std::exception &e) {
     std::cerr << "Exception! " << e.what() << std::endl;
+    return 1;
   }
+  std::cerr << "Success!" << std::endl;
   return 0;
 }


### PR DESCRIPTION
This change introduces cpp-netlib for transport to the JSON LightStep endpoint. Still needs debugging, but replaces vastly inferior code and isolates the primitive JsonEncoder class for writing custom transports.