### PR TITLE
src: missing header for std::function

### DIFF
--- a/src/c++11/lightstep/options.h
+++ b/src/c++11/lightstep/options.h
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <memory>
+#include <functional>
 
 #include "lightstep/util.h"
 #include "lightstep/value.h"


### PR DESCRIPTION
gcc-c++ 7.1.1 fails build without this include:
```
./lightstep/options.h:42:8: error: 'function' in namespace 'std' does not name a template type
   std::function<uint64_t()> guid_generator;
        ^~~~~~~~
```

See related issue: https://github.com/lyft/envoy/issues/1387

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>