### PR TITLE
Use an abstract class for AsyncTransporter's callback.

### DIFF
--- a/c++11/include/lightstep/transporter.h
+++ b/c++11/include/lightstep/transporter.h
@@ -25,16 +25,23 @@ class SyncTransporter : public Transporter {
 // AsyncTransporter customizes how asynchronous tracing reports are sent.
 class AsyncTransporter : public Transporter {
  public:
+  // Callback interface used by Send.
+  class Callback {
+   public:
+    virtual ~Callback() = default;
+
+    virtual void OnSuccess() noexcept = 0;
+
+    virtual void OnFailure(std::error_code error) noexcept = 0;
+  };
+
   // Asynchronously sends `request` to a collector.
   //
   // On success, `response` is set to the collector's response and
-  // `on_success(context)` is called.
+  // `callback.OnSuccess()` should be called.
   //
-  // On failure, `on_failure(error, context)` is called.
+  // On failure, `callback.OnFailure(error)` should be called.
   virtual void Send(const google::protobuf::Message& request,
-                    google::protobuf::Message& response,
-                    void (*on_success)(void* context),
-                    void (*on_failure)(std::error_code error, void* context),
-                    void* context) = 0;
+                    google::protobuf::Message& response, Callback& callback) {}
 };
 }  // namespace lightstep

--- a/c++11/src/manual_recorder.h
+++ b/c++11/src/manual_recorder.h
@@ -8,7 +8,7 @@
 namespace lightstep {
 // ManualRecorder buffers spans finished by a tracer and sends them over to
 // the provided AsyncTransporter when FlushWithTimeout is called.
-class ManualRecorder : public Recorder {
+class ManualRecorder : public Recorder, private AsyncTransporter::Callback {
  public:
   ManualRecorder(spdlog::logger& logger, LightStepTracerOptions options,
                  std::unique_ptr<AsyncTransporter>&& transporter);
@@ -21,8 +21,8 @@ class ManualRecorder : public Recorder {
  private:
   bool FlushOne();
 
-  static void OnSuccessCallback(void* context);
-  static void OnFailureCallback(std::error_code error, void* context);
+  void OnSuccess() noexcept override;
+  void OnFailure(std::error_code error) noexcept override;
 
   spdlog::logger& logger_;
   LightStepTracerOptions options_;


### PR DESCRIPTION
This refactors `AsyncTransporter`'s callback to use a class instead of function pointers. It makes the code simpler to use since there are fewer variables to keep track of an matches the design used by [envoy](https://github.com/lyft/envoy/blob/master/include/envoy/http/async_client.h#L29).