### PR TITLE
Add MetricsObserver.

### DIFF
--- a/c++11/include/lightstep/metrics_observer.h
+++ b/c++11/include/lightstep/metrics_observer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace lightstep {
+// MetricsObserver can be used to track LightStep tracer events.
+class MetricsObserver {
+ public:
+  virtual ~MetricsObserver() = default;
+
+  // OnSpansSent records spans successfully flushed.
+  virtual void OnSpansSent(int num_spans) {}
+
+  // OnSpansDropped records spans dropped.
+  virtual void OnSpansDropped(int num_spans) {}
+
+  // OnFlush records flush events by the recorder.
+  virtual void OnFlush() {}
+};
+}  // namespace lightstep

--- a/c++11/include/lightstep/tracer.h
+++ b/c++11/include/lightstep/tracer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <lightstep/metrics_observer.h>
 #include <lightstep/transporter.h>
 #include <opentracing/tracer.h>
 #include <opentracing/value.h>
@@ -74,8 +75,12 @@ struct LightStepTracerOptions {
   // default transporter is used.
   //
   // If `use_thread` is true, `transporter` should be derived from
-  // AsyncTransporter; otherwise, it should be derived from SyncTransporter.
+  // AsyncTransporter; otherwise, it must be derived from SyncTransporter.
   std::unique_ptr<Transporter> transporter;
+
+  // `metrics_observer` can be optionally provided to track LightStep tracer
+  // events. See MetricsObserver.
+  std::unique_ptr<MetricsObserver> metrics_observer;
 };
 
 // The LightStepTracer interface can be used by custom carriers that need more

--- a/c++11/src/auto_recorder.h
+++ b/c++11/src/auto_recorder.h
@@ -51,7 +51,7 @@ class AutoRecorder : public Recorder {
   bool WaitForNextWrite(const std::chrono::steady_clock::time_point& next);
 
   Logger& logger_;
-  const LightStepTracerOptions options_;
+  LightStepTracerOptions options_;
 
   // Writer state.
   std::mutex write_mutex_;

--- a/c++11/src/manual_recorder.cpp
+++ b/c++11/src/manual_recorder.cpp
@@ -9,26 +9,36 @@ ManualRecorder::ManualRecorder(Logger& logger, LightStepTracerOptions options,
     : logger_{logger},
       options_{std::move(options)},
       builder_{options_.access_token, options_.tags},
-      transporter_{std::move(transporter)} {}
+      transporter_{std::move(transporter)} {
+  // If no MetricsObserver was provided, use a default one that does nothing.
+  if (options_.metrics_observer == nullptr) {
+    options_.metrics_observer.reset(new MetricsObserver{});
+  }
+}
 
 //------------------------------------------------------------------------------
 // RecordSpan
 //------------------------------------------------------------------------------
-void ManualRecorder::RecordSpan(collector::Span&& span) noexcept {
+void ManualRecorder::RecordSpan(collector::Span&& span) noexcept try {
   if (builder_.num_pending_spans() >= options_.max_buffered_spans) {
     dropped_spans_++;
+    options_.metrics_observer->OnSpansDropped(1);
     return;
   }
   builder_.AddSpan(std::move(span));
   if (builder_.num_pending_spans() >= options_.max_buffered_spans) {
     FlushOne();
   }
+} catch (const std::exception& e) {
+  logger_.Error("Failed to record span: ", e.what());
 }
 
 //------------------------------------------------------------------------------
 // FlushOne
 //------------------------------------------------------------------------------
-bool ManualRecorder::FlushOne() {
+bool ManualRecorder::FlushOne() noexcept try {
+  options_.metrics_observer->OnFlush();
+
   // If a report is currently in flight, do nothing; and if there are any
   // pending spans, then the flush is considered to have failed.
   if (encoding_seqno_ > 1 + flushed_seqno_) {
@@ -46,6 +56,12 @@ bool ManualRecorder::FlushOne() {
   ++encoding_seqno_;
   transporter_->Send(active_request_, active_response_, *this);
   return true;
+} catch (const std::exception& e) {
+  logger_.Error("Failed to Flush: ", e.what());
+  options_.metrics_observer->OnSpansDropped(saved_pending_spans_);
+  dropped_spans_ += saved_pending_spans_;
+  active_request_.Clear();
+  return false;
 }
 
 //------------------------------------------------------------------------------
@@ -62,6 +78,7 @@ bool ManualRecorder::FlushWithTimeout(
 void ManualRecorder::OnSuccess() noexcept {
   ++flushed_seqno_;
   active_request_.Clear();
+  options_.metrics_observer->OnSpansSent(saved_pending_spans_);
   if (options_.verbose) {
     logger_.Info(R"(Report: resp=")", active_response_.ShortDebugString(),
                  R"(")");
@@ -74,6 +91,7 @@ void ManualRecorder::OnSuccess() noexcept {
 void ManualRecorder::OnFailure(std::error_code error) noexcept {
   ++flushed_seqno_;
   active_request_.Clear();
+  options_.metrics_observer->OnSpansDropped(saved_pending_spans_);
   dropped_spans_ += saved_dropped_spans_ + saved_pending_spans_;
   logger_.Error("Failed to send report: ", error.message());
 }

--- a/c++11/src/manual_recorder.h
+++ b/c++11/src/manual_recorder.h
@@ -19,7 +19,7 @@ class ManualRecorder : public Recorder, private AsyncTransporter::Callback {
       std::chrono::system_clock::duration timeout) noexcept override;
 
  private:
-  bool FlushOne();
+  bool FlushOne() noexcept;
 
   void OnSuccess() noexcept override;
   void OnFailure(std::error_code error) noexcept override;

--- a/c++11/test/counting_metrics_observer.h
+++ b/c++11/test/counting_metrics_observer.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <lightstep/metrics_observer.h>
+#include <atomic>
+
+namespace lightstep {
+struct CountingMetricsObserver : MetricsObserver {
+  void OnSpansSent(int num_spans) override { num_spans_sent += num_spans; }
+
+  void OnSpansDropped(int num_spans) override {
+    num_spans_dropped += num_spans;
+  }
+
+  void OnFlush() override { ++num_flushes; }
+
+  std::atomic<int> num_flushes{0};
+  std::atomic<int> num_spans_sent{0};
+  std::atomic<int> num_spans_dropped{0};
+};
+}  // namespace lightstep

--- a/c++11/test/recorder_test.cpp
+++ b/c++11/test/recorder_test.cpp
@@ -3,6 +3,7 @@
 #include "../src/auto_recorder.h"
 #include "../src/lightstep_tracer_impl.h"
 #include "../src/manual_recorder.h"
+#include "counting_metrics_observer.h"
 #include "in_memory_transporter.h"
 #include "testing_condition_variable_wrapper.h"
 
@@ -32,12 +33,12 @@ static int LookupSpansDropped(const collector::ReportRequest& report) {
 }
 
 TEST_CASE("auto_recorder") {
-  /* spdlog::logger logger{"lightstep",
-   * spdlog::sinks::stderr_sink_mt::instance()}; */
   Logger logger{};
+  auto metrics_observer = new CountingMetricsObserver{};
   LightStepTracerOptions options;
   options.reporting_period = std::chrono::milliseconds{2};
   options.max_buffered_spans = 5;
+  options.metrics_observer.reset(metrics_observer);
   auto in_memory_transporter = new InMemorySyncTransporter{};
   auto condition_variable = new TestingConditionVariableWrapper{};
   auto recorder = new AutoRecorder{
@@ -97,7 +98,7 @@ TEST_CASE("auto_recorder") {
   SECTION(
       "If the transporter's SendReport function throws, we drop all subsequent "
       "spans.") {
-    /* logger.set_level(spdlog::level::off); */
+    logger.set_level(LogLevel::off);
     in_memory_transporter->set_should_throw(true);
 
     // Wait until the writer thread is ready to run.
@@ -149,12 +150,50 @@ TEST_CASE("auto_recorder") {
     CHECK(LookupSpansDropped(reports.at(1)) == 0);
     CHECK(reports.at(1).spans_size() == 1);
   }
+
+  SECTION(
+      "MetricsObserver::OnFlush gets called whenever the recorder is "
+      "successfully flushed.") {
+    auto span = tracer->StartSpan("abc");
+    span->Finish();
+    condition_variable->Step();
+    tracer->Close();
+    CHECK(metrics_observer->num_flushes == 1);
+  }
+
+  SECTION(
+      "MetricsObserver::OnSpansSent gets called with the number of spans "
+      "successfully transported") {
+    auto span1 = tracer->StartSpan("abc");
+    span1->Finish();
+    auto span2 = tracer->StartSpan("abc");
+    span2->Finish();
+    condition_variable->Step();
+    tracer->Close();
+    CHECK(metrics_observer->num_spans_sent == 2);
+  }
+
+  SECTION(
+      "MetricsObserver::OnSpansDropped gets called when spans are dropped.") {
+    condition_variable->set_block_notify_all(true);
+    for (size_t i = 0; i < options.max_buffered_spans + 1; ++i) {
+      auto span = tracer->StartSpan("abc");
+      CHECK(span);
+      span->Finish();
+    }
+    condition_variable->set_block_notify_all(false);
+    condition_variable->Step();
+    tracer->Close();
+    CHECK(metrics_observer->num_spans_dropped == 1);
+  }
 }
 
 TEST_CASE("manual_recorder") {
   Logger logger{};
+  auto metrics_observer = new CountingMetricsObserver{};
   LightStepTracerOptions options;
   options.max_buffered_spans = 5;
+  options.metrics_observer.reset(metrics_observer);
   auto in_memory_transporter = new InMemoryAsyncTransporter{};
   auto recorder = new ManualRecorder{
       logger, std::move(options),
@@ -211,5 +250,40 @@ TEST_CASE("manual_recorder") {
     }
     in_memory_transporter->Write();
     CHECK(in_memory_transporter->reports().size() == 1);
+  }
+
+  SECTION(
+      "MetricsObserver::OnFlush gets called whenever the recorder is "
+      "successfully flushed.") {
+    auto span = tracer->StartSpan("abc");
+    span->Finish();
+    tracer->Flush();
+    in_memory_transporter->Write();
+    CHECK(metrics_observer->num_flushes == 1);
+  }
+
+  SECTION(
+      "MetricsObserver::OnSpansSent gets called with the number of spans "
+      "successfully transported") {
+    auto span1 = tracer->StartSpan("abc");
+    span1->Finish();
+    auto span2 = tracer->StartSpan("abc");
+    span2->Finish();
+    tracer->Flush();
+    in_memory_transporter->Write();
+    CHECK(metrics_observer->num_spans_sent == 2);
+  }
+
+  SECTION(
+      "MetricsObserver::OnSpansDropped gets called when spans are dropped.") {
+    logger.set_level(LogLevel::off);
+    auto span1 = tracer->StartSpan("abc");
+    span1->Finish();
+    auto span2 = tracer->StartSpan("abc");
+    span2->Finish();
+    tracer->Flush();
+    in_memory_transporter->Fail(
+        std::make_error_code(std::errc::network_unreachable));
+    CHECK(metrics_observer->num_spans_dropped == 2);
   }
 }


### PR DESCRIPTION
Adds a MetricObserver option to support recording this [metric](https://github.com/rnburn/envoy/blob/checkpoint0/source/common/tracing/lightstep_tracer_impl.cc#L87) currently used by envoy.

I know we discussed this as being similar to the [SpanRecorder](https://github.com/lightstep/lightstep-tracer-go/blob/master/options.go#L142) option in the Go tracer. But there are some differences since envoy updates the metric when the spans get flushed; whereas the SpanRecorder gets called earlier when the span is finished, which is why I didn't copy the SpanRecorder over exactly. I added a few similar to metrics to flesh this out a bit; even though envoy wouldn't use all of them.