### PR TITLE
Minor fixes to CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 project(lightstep-tracer)
 
@@ -38,6 +38,7 @@ option(ENABLE_LINTING "Run clang-tidy on sources if available." ON)
 # Configure compiler warnings
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(WARNING_CXX_FLAGS -Weverything 
     -Wno-c++98-compat 


### PR DESCRIPTION
* Require at least CMake version 3.1 since that's when CXX_STANDARD was [added](https://cmake.org/cmake/help/v3.1/variable/CMAKE_CXX_STANDARD.html).
* Set CMAKE_CXX_STANDARD_REQUIRED to give a clearer error message for unsupported compilers.