### PR TITLE
lightstep_span_context: remove noexcept on default constructor.

### DIFF
--- a/src/lightstep_span_context.h
+++ b/src/lightstep_span_context.h
@@ -10,7 +10,7 @@
 namespace lightstep {
 class LightStepSpanContext : public opentracing::SpanContext {
  public:
-  LightStepSpanContext() noexcept = default;
+  LightStepSpanContext() = default;
 
   LightStepSpanContext(
       uint64_t trace_id, uint64_t span_id,


### PR DESCRIPTION
Google's internal Clang is complaining about:

external/com_github_lightstep_lightstep_tracer_cpp/src/lightstep_span_context.h:13:3:
error: exception specification of explicitly defaulted default
constructor does not match the calculated one
  LightStepSpanContext() noexcept = default;

I'm thinking that since the member unordered_map constructor is not
explicitly noexcept, this doesn't allow the object to have a default
noexcept constructor.

Signed-off-by: Harvey Tuch <htuch@google.com>