### PR TITLE
Support embedding root certificates.

### DIFF
--- a/3rd_party/CMakeLists.txt
+++ b/3rd_party/CMakeLists.txt
@@ -10,3 +10,5 @@ add_library(lightstep_3rd_party OBJECT base64/src/base64.cpp)
 if (BUILD_SHARED_LIBS)
   set_property(TARGET lightstep_3rd_party PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
+
+add_executable(embedfile embedfile/src/embedfile.c)

--- a/3rd_party/embedfile/src/embedfile.c
+++ b/3rd_party/embedfile/src/embedfile.c
@@ -1,0 +1,57 @@
+// Taken from https://stackoverflow.com/a/11814544/4447365
+
+#include <stdlib.h>
+#include <stdio.h>
+
+FILE* open_or_exit(const char* fname, const char* mode)
+{
+  FILE* f = fopen(fname, mode);
+  if (f == NULL) {
+    perror(fname);
+    exit(EXIT_FAILURE);
+  }
+  return f;
+}
+
+int main(int argc, char** argv)
+{
+  if (argc < 3) {
+    fprintf(stderr, "USAGE: %s {sym} {rsrc}\n\n"
+        "  Creates {sym}.cpp from the contents of {rsrc}\n",
+        argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  const char* sym = argv[1];
+  FILE* in = open_or_exit(argv[2], "r");
+
+  char symfile[256];
+  snprintf(symfile, sizeof(symfile), "%s.cpp", sym);
+
+  FILE* out = open_or_exit(symfile,"w");
+  fprintf(out, "namespace lightstep {\n");
+  fprintf(out, "extern const unsigned char %s[];\n", sym);
+  fprintf(out, "extern const int %s_size;\n", sym);
+  fprintf(out, "const unsigned char %s[] = {\n", sym);
+
+  unsigned char buf[256];
+  size_t nread = 0;
+  size_t linecount = 0;
+  do {
+    nread = fread(buf, 1, sizeof(buf), in);
+    size_t i;
+    for (i=0; i < nread; i++) {
+      fprintf(out, "0x%02x, ", buf[i]);
+      if (++linecount == 10) { fprintf(out, "\n"); linecount = 0; }
+    }
+  } while (nread > 0);
+  if (linecount > 0) fprintf(out, "\n");
+  fprintf(out, "};\n");
+  fprintf(out, "const int %s_size = static_cast<int>(sizeof(%s));\n\n",sym,sym);
+  fprintf(out, "} //namespace lightstep\n");
+
+  fclose(in);
+  fclose(out);
+
+  return EXIT_SUCCESS;
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,18 @@ option(WITH_DYNAMIC_LOAD "Build support for dynamic loading." ON)
 option(ENABLE_LINTING "Run clang-tidy on sources if available." ON)
 option(HEADERS_ONLY "Only generate config.h and version.h." OFF)
 
+# Allow a user to specify an optional default roots.pem file to embed into the 
+# library. 
+#
+# This is useful if the library is distributed to an environment where gRPC
+# hasn't been installed.
+#
+# To use, invoke cmake with 
+#   cmake -DDEFAULT_SSL_ROOTS_PEM:STRING=/path/to/roots.pem ...
+#
+# See also discussion on https://github.com/grpc/grpc/issues/4834
+set(DEFAULT_SSL_ROOTS_PEM "" CACHE STRING "Path to a default roots.pem file to embed")
+
 if (WITH_GRPC)
   set(LIGHTSTEP_USE_GRPC 1)
 elseif(WITH_DYNAMIC_LOAD)
@@ -151,8 +163,22 @@ set(LIGHTSTEP_SRCS src/utility.cpp
                    src/lightstep_tracer_factory.cpp
                    src/transporter.cpp
                    src/tracer.cpp)
+
 if (WITH_DYNAMIC_LOAD)
   list(APPEND LIGHTSTEP_SRCS src/dynamic_load.cpp)
+endif()
+
+if (DEFAULT_SSL_ROOTS_PEM STREQUAL "")
+  list(APPEND LIGHTSTEP_SRCS src/no_default_ssl_roots_pem.cpp)
+else()
+  # Follows the approach described in https://stackoverflow.com/a/11814544/4447365
+  set(EMBED_SSL_ROOTS_PEM_CPP_FILE ${CMAKE_BINARY_DIR}/default_ssl_roots_pem.cpp)
+  add_custom_command(
+    OUTPUT ${EMBED_SSL_ROOTS_PEM_CPP_FILE}
+    COMMAND embedfile default_ssl_roots_pem ${DEFAULT_SSL_ROOTS_PEM}
+    DEPENDS ${DEFAULT_ROOT_PEM}
+  )
+  list(APPEND LIGHTSTEP_SRCS ${EMBED_SSL_ROOTS_PEM_CPP_FILE})
 endif()
 
 add_library(lightstep_tracer $<TARGET_OBJECTS:lightstep_tracer_common>

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -37,6 +37,7 @@ elif [[ "$1" == "cmake.tsan" ]]; then
         -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer -fsanitize=thread"  \
         -DCMAKE_SHARED_LINKER_FLAGS="-fno-omit-frame-pointer -fsanitize=thread" \
         -DCMAKE_EXE_LINKER_FLAGS="-fno-omit-frame-pointer -fsanitize=thread" \
+        -DWITH_DYNAMIC_LOAD=OFF \
         "${SRC_DIR}"
   make VERBOSE=1
   make test

--- a/include/lightstep/tracer.h
+++ b/include/lightstep/tracer.h
@@ -73,6 +73,13 @@ struct LightStepTracerOptions {
   // key in TextMap and HTTPHeaders carriers.
   bool use_single_key_propagation = false;
 
+  // Set `ssl_root_certificates` to specify the CA certificates to use when
+  // transporting spans to the collector.  If not set, LightStep will try to
+  // use CA certifications located in standard system locations.
+  //
+  // Note: `ssl_root_certificates` should follow the PEM format.
+  std::string ssl_root_certificates;
+
   // Set `logger_sink` to a custom function to override where logging is
   // printed; otherwise, it defaults to stderr.
   std::function<void(LogLevel, opentracing::string_view)> logger_sink;

--- a/include/lightstep/tracer.h
+++ b/include/lightstep/tracer.h
@@ -75,7 +75,7 @@ struct LightStepTracerOptions {
 
   // Set `ssl_root_certificates` to specify the CA certificates to use when
   // transporting spans to the collector.  If not set, LightStep will try to
-  // use CA certifications located in standard system locations.
+  // use CA certificates located in standard system locations.
   //
   // Note: `ssl_root_certificates` should follow the PEM format.
   std::string ssl_root_certificates;

--- a/lightstep-tracer-configuration/tracer_configuration.proto
+++ b/lightstep-tracer-configuration/tracer_configuration.proto
@@ -42,7 +42,7 @@ message TracerConfiguration {
 
   // `ssl_root_certificates` specifies the CA certificates to use when
   // transporting spans to the collector.  If not set, LightStep will try to 
-  // use CA certifications located in standard system locations.
+  // use CA certificates located in standard system locations.
   //
   // Note: `ssl_root_certificates` should follow the PEM format.
   string ssl_root_certificates = 10;

--- a/lightstep-tracer-configuration/tracer_configuration.proto
+++ b/lightstep-tracer-configuration/tracer_configuration.proto
@@ -39,4 +39,11 @@ message TracerConfiguration {
   // `report_timeout` is the timeout to use when sending a reports to the
   // collector. Ignored if a custom transport is used. (In microseconds).
   uint32 report_timeout = 9;
+
+  // `ssl_root_certificates` specifies the CA certificates to use when
+  // transporting spans to the collector.  If not set, LightStep will try to 
+  // use CA certifications located in standard system locations.
+  //
+  // Note: `ssl_root_certificates` should follow the PEM format.
+  string ssl_root_certificates = 10;
 }

--- a/src/no_default_ssl_roots_pem.cpp
+++ b/src/no_default_ssl_roots_pem.cpp
@@ -1,0 +1,8 @@
+namespace lightstep {
+extern const unsigned char default_ssl_roots_pem[];
+extern const int default_ssl_roots_pem_size;
+
+// Add a signle element to appease -Wzero-length-array
+const unsigned char default_ssl_roots_pem[] = {'\0'};
+const int default_ssl_roots_pem_size = 0;
+}  // namespace lightstep


### PR DESCRIPTION
* Adds support to embed a default root certificates file at build time.
* Supports specifying the root certificates via the tracer's configuration.

These features will be used to make a portable plugin that can work in environments where gRPC hasn't been installed and won't require fiddling with the GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environmental variable.