### PR TITLE
Support multikey-single key context interoperability.

### DIFF
--- a/src/propagation.cpp
+++ b/src/propagation.cpp
@@ -341,12 +341,18 @@ static opentracing::expected<bool> ExtractSpanContext(
     uint64_t& span_id, std::unordered_map<std::string, std::string>& baggage,
     KeyCompare key_compare) {
   if (propagation_options.use_single_key) {
-    return ExtractSpanContextSingleKey(carrier, trace_id, span_id, baggage,
-                                       key_compare);
-  } else {
-    return ExtractSpanContextMultiKey(carrier, trace_id, span_id, baggage,
-                                      key_compare);
+    auto span_context_maybe = ExtractSpanContextSingleKey(
+        carrier, trace_id, span_id, baggage, key_compare);
+
+    // If no span context was found, fall back to multikey extraction so as to
+    // support interoperability with other tracers.
+    if (!span_context_maybe || *span_context_maybe) {
+      return span_context_maybe;
+    }
   }
+
+  return ExtractSpanContextMultiKey(carrier, trace_id, span_id, baggage,
+                                    key_compare);
 }
 
 opentracing::expected<bool> ExtractSpanContext(

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -230,11 +230,15 @@ TEST_CASE("propagation") {
 }
 
 TEST_CASE("propagation - single key") {
-  auto recorder = new InMemoryRecorder();
+  auto recorder = new InMemoryRecorder{};
   PropagationOptions propagation_options;
   propagation_options.use_single_key = true;
   auto tracer = std::shared_ptr<opentracing::Tracer>{new LightStepTracerImpl{
       propagation_options, std::unique_ptr<Recorder>{recorder}}};
+  auto multikey_tracer =
+      std::shared_ptr<opentracing::Tracer>{new LightStepTracerImpl{
+          PropagationOptions{},
+          std::unique_ptr<Recorder>{new InMemoryRecorder{}}}};
   std::unordered_map<std::string, std::string> text_map;
   TextMapCarrier text_map_carrier(text_map);
   auto span = tracer->StartSpan("a");
@@ -260,13 +264,26 @@ TEST_CASE("propagation - single key") {
   }
 
   SECTION(
+      "Extract falls back to the multikey format if it doesn't find a "
+      "single-key header") {
+    text_map.clear();
+    CHECK(multikey_tracer->Inject(span->context(), text_map_carrier));
+    CHECK(text_map.size() > 1);
+    auto span_context_maybe = tracer->Extract(text_map_carrier);
+    CHECK((span_context_maybe && span_context_maybe->get()));
+  }
+
+  SECTION(
       "When LookupKey is used, a nullptr is returned if there is no "
       "span_context") {
     text_map.clear();
     text_map_carrier.supports_lookup = true;
     auto span_context_maybe = tracer->Extract(text_map_carrier);
     CHECK((span_context_maybe && span_context_maybe->get() == nullptr));
-    CHECK(text_map_carrier.foreach_key_call_count == 0);
+
+    // We have to iterate through all of the keys once when extraction falls
+    // back to the multikey format.
+    CHECK(text_map_carrier.foreach_key_call_count == 1);
   }
 
   SECTION("Verify only valid base64 characters are used.") {


### PR DESCRIPTION
With this PR, if a tracer set up for single key propagation fails to extract a span context, it will fall back to attempting multi-key extraction.

It means doing more work in some cases but improves interoperability.

Not sure if  we might want an option to control this behavior?