### PR TITLE
Auto-attach plugin on release.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,24 @@ jobs:
       - run: ./ci/setup_build_environment.sh
       - run: ./ci/install_bazel.sh
       - run: ./ci/do_ci.sh bazel.build
+  release:
+    docker:
+      - image: ubuntu:17.10
+    steps:
+      - checkout
+      - run: ./ci/setup_build_environment.sh
+      - run: ./ci/do_ci.sh release
 
 workflows:
   version: 2
   build_test_and_deploy:
     jobs:
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
       - asan
       - tsan
       - build_with_no_grpc

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -46,9 +46,13 @@ elif [[ "$1" == "cmake.tsan" ]]; then
   exit 0
 elif [[ "$1" == "plugin" ]]; then
   cd "${BUILD_DIR}"
-  "${SRC_DIR}"/ci//build_plugin.sh
+  "${SRC_DIR}"/ci/build_plugin.sh
   exit 0
 elif [[ "$1" == "bazel.build" ]]; then
   bazel build //...
+  exit 0
+elif [[ "$1" == "release" ]]; then
+  "${SRC_DIR}"/ci/build_plugin.sh
+  "${SRC_DIR}"/ci/release.sh
   exit 0
 fi

--- a/ci/release.sh
+++ b/ci/release.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+apt-get update 
+apt-get install --no-install-recommends --no-install-suggests -y \
+                wget \
+                unzip
+
+# Install ghr
+cd /
+wget https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip
+unzip ghr_v0.5.4_linux_amd64.zip
+
+# Create packaged plugins
+gzip -c /liblightstep_tracer_plugin.so > /linux-amd64-liblightstep_tracer_plugin.so.gz
+
+# Create release
+cd "${SRC_DIR}"
+VERSION_TAG="`git describe --abbrev=0 --tags`"
+
+RELEASE_TITLE="${VERSION_TAG/v/Release }" 
+# No way to set title see https://github.com/tcnksm/ghr/issues/77
+
+echo "/ghr -t <hidden> \
+     -u $CIRCLE_PROJECT_USERNAME \
+     -r $CIRCLE_PROJECT_REPONAME \
+     -replace \
+     "${VERSION_TAG}" \
+     /linux-amd64-liblightstep_tracer_plugin.so.gz"
+/ghr -t $GITHUB_TOKEN \
+     -u $CIRCLE_PROJECT_USERNAME \
+     -r $CIRCLE_PROJECT_REPONAME \
+     -replace \
+     "${VERSION_TAG}" \
+     /linux-amd64-liblightstep_tracer_plugin.so.gz

--- a/ci/setup_build_environment.sh
+++ b/ci/setup_build_environment.sh
@@ -11,4 +11,5 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 automake \
                 autogen \
                 autoconf \
-                libtool
+                libtool \
+                ssh


### PR DESCRIPTION
* When a release tag is pushed, this change adds a circleci trigger that will build the tracer plugin and attach to the release.