### PR TITLE
Fix propagation test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   asan:
     docker:
-      - image: ubuntu:17.10
+      - image: ubuntu:18.04
     steps:
       - checkout
       - run: ./ci/setup_build_environment.sh
@@ -14,7 +14,7 @@ jobs:
           destination: Test.log
   tsan:
     docker:
-      - image: ubuntu:17.10
+      - image: ubuntu:18.04
     steps:
       - checkout
       - run: ./ci/setup_build_environment.sh
@@ -24,9 +24,22 @@ jobs:
       - store_artifacts:
           path: /build/Testing/Temporary/LastTest.log
           destination: Test.log
+  clang_tidy:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - checkout
+      - run: ./ci/setup_build_environment.sh
+      - run: ./ci/install_grpc.sh
+      - run: ./ci/install_opentracing.sh
+      - run: ./ci/install_clang.sh
+      - run: ./ci/do_ci.sh cmake.clang-tidy
+      - store_artifacts:
+          path: /build/Testing/Temporary/LastTest.log
+          destination: Test.log
   build_with_no_grpc:
     docker:
-      - image: ubuntu:17.10
+      - image: ubuntu:18.04
     steps:
       - checkout
       - run: ./ci/setup_build_environment.sh
@@ -38,7 +51,7 @@ jobs:
           destination: Test.log
   build_plugin:
     docker:
-      - image: ubuntu:17.10
+      - image: ubuntu:18.04
     steps:
       - checkout
       - run: ./ci/setup_build_environment.sh
@@ -48,7 +61,7 @@ jobs:
           destination: liblightstep_tracer_plugin.so
   build_bazel:
     docker:
-      - image: ubuntu:17.10
+      - image: ubuntu:18.04
     resource_class: large
     steps:
       - checkout
@@ -57,7 +70,7 @@ jobs:
       - run: ./ci/do_ci.sh bazel.build
   release:
     docker:
-      - image: ubuntu:17.10
+      - image: ubuntu:18.04
     steps:
       - run: apt-get -qq update; apt-get -y install git ssh
       - checkout
@@ -76,6 +89,7 @@ workflows:
               only: /^v[0-9]+(\.[0-9]+)*$/
       - asan
       - tsan
+      - clang_tidy
       - build_with_no_grpc
       - build_plugin
       - build_bazel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(CPack)
 
 option(WITH_GRPC "Build with support for gRPC." ON)
 option(WITH_DYNAMIC_LOAD "Build support for dynamic loading." ON)
-option(ENABLE_LINTING "Run clang-tidy on sources if available." ON)
+option(ENABLE_LINTING "Run clang-tidy on sources if available." OFF)
 option(HEADERS_ONLY "Only generate config.h and version.h." OFF)
 
 # Allow a user to specify an optional default roots.pem file to embed into the 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /3rd_party
 ADD setup_build_environment.sh /3rd_party
 ADD install_opentracing.sh /3rd_party
 ADD install_grpc.sh /3rd_party
+ADD install_clang.sh /3rd_party
 
 RUN /3rd_party/setup_build_environment.sh \
  && /3rd_party/install_opentracing.sh \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 WORKDIR /3rd_party
 
@@ -8,4 +8,5 @@ ADD install_grpc.sh /3rd_party
 
 RUN /3rd_party/setup_build_environment.sh \
  && /3rd_party/install_opentracing.sh \
- && /3rd_party/install_grpc.sh
+ && /3rd_party/install_grpc.sh \
+ && /3rd_party/install_clang.sh

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -9,6 +9,7 @@ mkdir -p "${BUILD_DIR}"
 if [[ "$1" == "cmake.debug" ]]; then
   cd "${BUILD_DIR}"
   cmake -DCMAKE_BUILD_TYPE=Debug  \
+        -DCMAKE_CXX_FLAGS="-Werror" \
         "${SRC_DIR}"
   make
   make test
@@ -16,6 +17,7 @@ if [[ "$1" == "cmake.debug" ]]; then
 elif [[ "$1" == "cmake.no_grpc" ]]; then
   cd "${BUILD_DIR}"
   cmake -DCMAKE_BUILD_TYPE=Debug  \
+        -DCMAKE_CXX_FLAGS="-Werror" \
         -DWITH_GRPC=OFF \
         "${SRC_DIR}"
   make
@@ -24,7 +26,7 @@ elif [[ "$1" == "cmake.no_grpc" ]]; then
 elif [[ "$1" == "cmake.asan" ]]; then
   cd "${BUILD_DIR}"
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer -fsanitize=address"  \
+        -DCMAKE_CXX_FLAGS="-Werror -fno-omit-frame-pointer -fsanitize=address"  \
         -DCMAKE_SHARED_LINKER_FLAGS="-fno-omit-frame-pointer -fsanitize=address" \
         -DCMAKE_EXE_LINKER_FLAGS="-fno-omit-frame-pointer -fsanitize=address" \
         "${SRC_DIR}"
@@ -36,12 +38,23 @@ elif [[ "$1" == "cmake.tsan" ]]; then
 # Testing with dynamic load seems to have some issues with TSAN so turn off
 # dynamic loading in this test for now.
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer -fsanitize=thread"  \
+        -DCMAKE_CXX_FLAGS="-Werror -fno-omit-frame-pointer -fsanitize=thread"  \
         -DCMAKE_SHARED_LINKER_FLAGS="-fno-omit-frame-pointer -fsanitize=thread" \
         -DCMAKE_EXE_LINKER_FLAGS="-fno-omit-frame-pointer -fsanitize=thread" \
         -DWITH_DYNAMIC_LOAD=OFF \
         "${SRC_DIR}"
   make VERBOSE=1
+  make test
+  exit 0
+elif [[ "$1" == "cmake.clang-tidy" ]]; then
+  cd "${BUILD_DIR}"
+  cmake -DCMAKE_BUILD_TYPE=Debug  \
+        -DCMAKE_C_COMPILER=/usr/bin/clang-6.0 \
+        -DCMAKE_CXX_COMPILER=/usr/bin/clang++-6.0 \
+        -DENABLE_LINTING=ON \
+        -DCMAKE_CXX_FLAGS="-Werror" \
+        "${SRC_DIR}"
+  make
   make test
   exit 0
 elif [[ "$1" == "plugin" ]]; then

--- a/ci/install_clang.sh
+++ b/ci/install_clang.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+apt-get install --no-install-recommends --no-install-suggests -y \
+                gnupg2 \
+                software-properties-common \
+                wget
+
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - 
+apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" 
+apt-get update 
+apt-get install -y clang-6.0 clang-tidy

--- a/ci/setup_build_environment.sh
+++ b/ci/setup_build_environment.sh
@@ -12,4 +12,5 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 autogen \
                 autoconf \
                 libtool \
+                gnupg2 \
                 ssh

--- a/cmake/Modules/LightStepClangTidy.cmake
+++ b/cmake/Modules/LightStepClangTidy.cmake
@@ -6,6 +6,7 @@ else()
   message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" 
 "-checks=*,\
+-fuchsia-*,
 -clang-analyzer-alpha.*,\
 -llvm-include-order,\
 -google-runtime-references,\

--- a/cmake/Modules/LightStepClangTidy.cmake
+++ b/cmake/Modules/LightStepClangTidy.cmake
@@ -1,4 +1,4 @@
-find_program(CLANG_TIDY_EXE NAMES "clang-tidy" 
+find_program(CLANG_TIDY_EXE NAMES "clang-tidy" "clang-tidy-5.0" "clang-tidy-6.0" "clang-tidy-7.0"
                             DOC "Path to clang-tidy executable")
 if(NOT CLANG_TIDY_EXE)
   message(STATUS "clang-tidy not found.")
@@ -10,7 +10,7 @@ else()
 -llvm-include-order,\
 -google-runtime-references,\
 -google-build-using-namespace,\
--cppcoreguidelines-pro-type-vararg")
+-cppcoreguidelines-pro-type-vararg;-warnings-as-errors=*")
 endif()
 
 macro(_apply_clang_tidy_if_available TARGET)

--- a/cmake/Modules/LightStepClangTidy.cmake
+++ b/cmake/Modules/LightStepClangTidy.cmake
@@ -11,7 +11,13 @@ else()
 -llvm-include-order,\
 -google-runtime-references,\
 -google-build-using-namespace,\
--cppcoreguidelines-pro-type-vararg;-warnings-as-errors=*")
+-modernize-make-unique,\
+-hicpp-vararg,\
+-cppcoreguidelines-owning-memory,\
+-cppcoreguidelines-pro-type-reinterpret-cast,\
+-cppcoreguidelines-pro-type-const-cast,\
+-cppcoreguidelines-pro-type-vararg;\
+-warnings-as-errors=*")
 endif()
 
 macro(_apply_clang_tidy_if_available TARGET)

--- a/cmake/Modules/LightStepClangTidy.cmake
+++ b/cmake/Modules/LightStepClangTidy.cmake
@@ -6,7 +6,7 @@ else()
   message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" 
 "-checks=*,\
--fuchsia-*,
+-fuchsia-*,\
 -clang-analyzer-alpha.*,\
 -llvm-include-order,\
 -google-runtime-references,\

--- a/include/lightstep/tracer.h
+++ b/include/lightstep/tracer.h
@@ -123,11 +123,16 @@ struct LightStepTracerOptions {
 // direct access to a span context's data so as to propagate more efficiently.
 class LightStepTracer : public opentracing::Tracer {
  public:
-  opentracing::expected<std::array<uint64_t, 2>> GetTraceSpanIds(
+  opentracing::expected<std::array<uint64_t, 3>> GetTraceSpanIdsSampled(
       const opentracing::SpanContext& span_context) const noexcept;
 
   opentracing::expected<std::unique_ptr<opentracing::SpanContext>>
   MakeSpanContext(uint64_t trace_id, uint64_t span_id,
+                  std::unordered_map<std::string, std::string>&& baggage) const
+      noexcept;
+
+  opentracing::expected<std::unique_ptr<opentracing::SpanContext>>
+  MakeSpanContext(uint64_t trace_id, uint64_t span_id, bool sampled,
                   std::unordered_map<std::string, std::string>&& baggage) const
       noexcept;
 

--- a/src/lightstep_span_context.cpp
+++ b/src/lightstep_span_context.cpp
@@ -82,4 +82,24 @@ void LightStepSpanContext::set_sampled(bool sampled) noexcept {
   std::lock_guard<std::mutex> lock_guard{mutex_};
   sampled_ = sampled;
 }
+
+//------------------------------------------------------------------------------
+// operator==
+//------------------------------------------------------------------------------
+bool operator==(const LightStepSpanContext& lhs,
+                const LightStepSpanContext& rhs) {
+  auto extract_baggage = [](const LightStepSpanContext& span_context) {
+    std::unordered_map<std::string, std::string> baggage;
+    span_context.ForeachBaggageItem(
+        [&](const std::string& key, const std::string& value) {
+          baggage.emplace(key, value);
+          return true;
+        });
+    return baggage;
+  };
+
+  return lhs.trace_id() == rhs.trace_id() && lhs.span_id() == rhs.span_id() &&
+         lhs.sampled() == rhs.sampled() &&
+         extract_baggage(lhs) == extract_baggage(rhs);
+}
 }  // namespace lightstep

--- a/src/lightstep_span_context.h
+++ b/src/lightstep_span_context.h
@@ -67,4 +67,12 @@ class LightStepSpanContext : public opentracing::SpanContext {
   bool sampled_ = true;
   std::unordered_map<std::string, std::string> baggage_;
 };
+
+bool operator==(const LightStepSpanContext& lhs,
+                const LightStepSpanContext& rhs);
+
+inline bool operator!=(const LightStepSpanContext& lhs,
+                       const LightStepSpanContext& rhs) {
+  return !(lhs == rhs);
+}
 }  // namespace lightstep

--- a/src/lightstep_tracer_impl.h
+++ b/src/lightstep_tracer_impl.h
@@ -14,7 +14,7 @@ class LightStepTracerImpl
                       std::unique_ptr<Recorder>&& recorder) noexcept;
 
   LightStepTracerImpl(std::shared_ptr<Logger> logger,
-                      const PropagationOptions& propgation_options,
+                      const PropagationOptions& propagation_options,
                       std::unique_ptr<Recorder>&& recorder) noexcept;
 
   std::unique_ptr<opentracing::Span> StartSpanWithOptions(

--- a/src/propagation.cpp
+++ b/src/propagation.cpp
@@ -208,10 +208,9 @@ opentracing::expected<void> InjectSpanContext(
   if (propagation_options.use_single_key) {
     return InjectSpanContextSingleKey(carrier, trace_id, span_id, sampled,
                                       baggage);
-  } else {
-    return InjectSpanContextMultiKey(carrier, trace_id, span_id, sampled,
-                                     baggage);
   }
+  return InjectSpanContextMultiKey(carrier, trace_id, span_id, sampled,
+                                   baggage);
 }
 
 //------------------------------------------------------------------------------
@@ -235,11 +234,7 @@ static opentracing::expected<bool> ExtractSpanContextMultiKey(
             span_id = HexToUint64(value);
             count++;
           } else if (key_compare(key, FieldNameSampled)) {
-            if (value == "false" || value == "0") {
-              sampled = false;
-            } else {
-              sampled = true;
-            }
+            sampled = !(value == "false" || value == "0");
             count++;
           } else if (key.length() > PrefixBaggage.size() &&
                      key_compare(opentracing::string_view{key.data(),
@@ -281,9 +276,8 @@ static opentracing::expected<bool> ExtractSpanContextSingleKey(
   if (!value_maybe) {
     if (value_maybe.error() == opentracing::key_not_found_error) {
       return false;
-    } else {
-      return opentracing::make_unexpected(value_maybe.error());
     }
+    return opentracing::make_unexpected(value_maybe.error());
   }
   auto value = *value_maybe;
   std::string base64_decoding;

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -59,9 +59,10 @@ const std::string& CollectorMethodName() {
 }
 
 //------------------------------------------------------------------------------
-// GetTraceSpanIds
+// GetTraceSpanIdsSampled
 //------------------------------------------------------------------------------
-opentracing::expected<std::array<uint64_t, 2>> LightStepTracer::GetTraceSpanIds(
+opentracing::expected<std::array<uint64_t, 3>>
+LightStepTracer::GetTraceSpanIdsSampled(
     const opentracing::SpanContext& span_context) const noexcept {
   auto lightstep_span_context =
       dynamic_cast<const LightStepSpanContext*>(&span_context);
@@ -69,8 +70,9 @@ opentracing::expected<std::array<uint64_t, 2>> LightStepTracer::GetTraceSpanIds(
     return opentracing::make_unexpected(
         opentracing::invalid_span_context_error);
   }
-  std::array<uint64_t, 2> result = {
-      {lightstep_span_context->trace_id(), lightstep_span_context->span_id()}};
+  std::array<uint64_t, 3> result = {
+      {lightstep_span_context->trace_id(), lightstep_span_context->span_id(),
+       static_cast<uint64_t>(lightstep_span_context->sampled())}};
   return result;
 }
 
@@ -79,10 +81,10 @@ opentracing::expected<std::array<uint64_t, 2>> LightStepTracer::GetTraceSpanIds(
 //------------------------------------------------------------------------------
 opentracing::expected<std::unique_ptr<opentracing::SpanContext>>
 LightStepTracer::MakeSpanContext(
-    uint64_t trace_id, uint64_t span_id,
+    uint64_t trace_id, uint64_t span_id, bool sampled,
     std::unordered_map<std::string, std::string>&& baggage) const noexcept try {
   std::unique_ptr<opentracing::SpanContext> result{
-      new LightStepSpanContext{trace_id, span_id, std::move(baggage)}};
+      new LightStepSpanContext{trace_id, span_id, sampled, std::move(baggage)}};
   return std::move(result);
 } catch (const std::bad_alloc&) {
   return opentracing::make_unexpected(

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -44,7 +44,7 @@ std::string GetProgramName() {
   }
   std::string path(exe_path.get(), size);
   size_t lslash = path.rfind('/');
-  if (lslash != path.npos) {
+  if (lslash != std::string::npos) {
     return path.substr(lslash + 1);
   }
   return path;

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -196,7 +196,6 @@ TEST_CASE("propagation") {
       CHECK_NOTHROW(VerifyInjectExtract(*tracer, *span_context, ss));
 
       // binary carrier
-      text_map.clear();
       CHECK_NOTHROW(
           VerifyInjectExtract(*tracer, *span_context, binary_reader_writer));
       // Note: binary injection clears the existing values so no need to reset.

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -152,9 +152,12 @@ static void VerifyInjectExtract(const opentracing::Tracer& tracer,
                              rcode.error().message()};
   }
   auto span_context_maybe = tracer.Extract(carrier);
-  if (!span_context_maybe || *span_context_maybe == nullptr) {
+  if (!span_context_maybe) {
     throw std::runtime_error{"failed to extract span context: " +
                              span_context_maybe.error().message()};
+  }
+  if (*span_context_maybe == nullptr) {
+    throw std::runtime_error{"no span context extracted"};
   }
 
   if (!AreSpanContextsEquivalent(span_context, **span_context_maybe)) {


### PR DESCRIPTION
* Refactors the propagation test coverage to better detect injection/extraction errors.
* Sets up clang-tidy to run as part of CI testing.
(I also verified that the [implicit-bool](https://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-conversion.html) conversion check runs).