### PR TITLE
Use a single ares channel per dns resolution.

### DIFF
--- a/example/stream/main.cpp
+++ b/example/stream/main.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 
 static void MakeSpan(opentracing::Tracer& tracer, int span_index) {
+  std::cout << "Make Span: " << span_index << "\n";
   auto span = tracer.StartSpan("span_" + std::to_string(span_index));
   assert(span != nullptr);
   for (int tag_index = 0; tag_index < 25; ++tag_index) {
@@ -34,7 +35,7 @@ int main() {
   for (int i = 0; i < 1000; ++i) {
     MakeSpan(*tracer, i);
   }
-  std::cout << "Closing tracer" << std::endl;
+  std::cout << "Closing tracer\n";
   tracer->Close();
   return 0;
 }

--- a/src/recorder/stream_recorder/satellite_dns_resolution_manager.h
+++ b/src/recorder/stream_recorder/satellite_dns_resolution_manager.h
@@ -11,6 +11,7 @@
 #include "network/ip_address.h"
 #include "network/timer_event.h"
 #include "recorder/stream_recorder/stream_recorder_options.h"
+#include "recorder/stream_recorder/satellite_dns_resolution_manager.h"
 
 namespace lightstep {
 /**
@@ -20,7 +21,6 @@ class SatelliteDnsResolutionManager final : public DnsResolutionCallback,
                                             private Noncopyable {
  public:
   SatelliteDnsResolutionManager(Logger& logger, EventBase& event_base,
-                                DnsResolver& dns_resolver,
                                 const StreamRecorderOptions& recorder_options,
                                 int family, const char* name,
                                 std::function<void()> on_ready_callback);
@@ -50,7 +50,7 @@ class SatelliteDnsResolutionManager final : public DnsResolutionCallback,
  private:
   Logger& logger_;
   EventBase& event_base_;
-  DnsResolver& dns_resolver_;
+  std::unique_ptr<DnsResolver> dns_resolver_;
   const StreamRecorderOptions& recorder_options_;
   int family_;
   const char* name_;

--- a/src/recorder/stream_recorder/satellite_dns_resolution_manager.h
+++ b/src/recorder/stream_recorder/satellite_dns_resolution_manager.h
@@ -11,7 +11,6 @@
 #include "network/ip_address.h"
 #include "network/timer_event.h"
 #include "recorder/stream_recorder/stream_recorder_options.h"
-#include "recorder/stream_recorder/satellite_dns_resolution_manager.h"
 
 namespace lightstep {
 /**

--- a/src/recorder/stream_recorder/satellite_endpoint_manager.cpp
+++ b/src/recorder/stream_recorder/satellite_endpoint_manager.cpp
@@ -13,9 +13,7 @@ SatelliteEndpointManager::SatelliteEndpointManager(
     const LightStepTracerOptions& tracer_options,
     const StreamRecorderOptions& recorder_options,
     std::function<void()> on_ready_callback)
-    : on_ready_callback_{std::move(on_ready_callback)},
-      dns_resolver_{MakeDnsResolver(logger, event_base,
-                                    recorder_options.dns_resolver_options)} {
+    : on_ready_callback_{std::move(on_ready_callback)} {
   if (tracer_options.satellite_endpoints.empty()) {
     throw std::runtime_error{"no satellite endpoints provided"};
   }
@@ -28,10 +26,10 @@ SatelliteEndpointManager::SatelliteEndpointManager(
   for (auto& name : hosts) {
     SatelliteHostManager host_manager;
     host_manager.ipv4_resolutions.reset(new SatelliteDnsResolutionManager{
-        logger, event_base, *dns_resolver_, recorder_options, AF_INET, name,
+        logger, event_base, recorder_options, AF_INET, name,
         on_resolution_ready});
     host_manager.ipv6_resolutions.reset(new SatelliteDnsResolutionManager{
-        logger, event_base, *dns_resolver_, recorder_options, AF_INET6, name,
+        logger, event_base, recorder_options, AF_INET6, name,
         on_resolution_ready});
     host_managers_.emplace_back(std::move(host_manager));
   }

--- a/src/recorder/stream_recorder/satellite_endpoint_manager.h
+++ b/src/recorder/stream_recorder/satellite_endpoint_manager.h
@@ -40,7 +40,6 @@ class SatelliteEndpointManager : private Noncopyable {
  private:
   std::function<void()> on_ready_callback_;
   std::vector<SatelliteHostManager> host_managers_;
-  std::unique_ptr<DnsResolver> dns_resolver_;
   std::vector<std::pair<int, uint16_t>> endpoints_;
   uint32_t endpoint_index_{0};
   int num_resolutions_ready_{0};

--- a/test/recorder/stream_recorder/satellite_dns_resolution_manager_test.cpp
+++ b/test/recorder/stream_recorder/satellite_dns_resolution_manager_test.cpp
@@ -33,14 +33,11 @@ TEST_CASE("SatelliteDnsResolutionManager") {
   Logger logger;
   EventBase event_base;
 
-  auto resolver = MakeDnsResolver(logger, event_base,
-                                  recorder_options.dns_resolver_options);
-
   std::function<void()> on_ready_callback = [&] { event_base.LoopBreak(); };
 
   SECTION("Hosts get resolved to ip addresses.") {
     SatelliteDnsResolutionManager resolution_manager{
-        logger,  event_base,     *resolver,        recorder_options,
+        logger,  event_base,            recorder_options,
         AF_INET, "test.service", on_ready_callback};
     resolution_manager.Start();
     event_base.Dispatch();
@@ -50,7 +47,7 @@ TEST_CASE("SatelliteDnsResolutionManager") {
 
   SECTION("Dns resolutions are periodically refreshed.") {
     SatelliteDnsResolutionManager resolution_manager{
-        logger,  event_base,     *resolver,        recorder_options,
+        logger,  event_base,            recorder_options,
         AF_INET, "flip.service", on_ready_callback};
     resolution_manager.Start();
     event_base.Dispatch();
@@ -69,7 +66,7 @@ TEST_CASE("SatelliteDnsResolutionManager") {
 
   SECTION("Dns resolutions are retried when if there's an error.") {
     SatelliteDnsResolutionManager resolution_manager{
-        logger,  event_base,      *resolver,        recorder_options,
+        logger,  event_base,             recorder_options,
         AF_INET, "flaky.service", on_ready_callback};
     resolution_manager.Start();
     event_base.Dispatch();


### PR DESCRIPTION
Makes changes to use a single ares channel per dns resolution (similar to [envoy](https://github.com/envoyproxy/envoy/issues/143#issuecomment-276765020)).

Otherwise, dns servers that don't respond can get in the way of other queries being processed.