### PR TITLE
[WIP] Optimize a span's protobuf serialization part 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ if (WITH_LIBEVENT)
   list(APPEND LIGHTSTEP_SRCS src/recorder/stream_recorder/stream_recorder.cpp
                              src/recorder/stream_recorder/stream_recorder2.cpp
                              src/recorder/stream_recorder/stream_recorder_impl.cpp
+                             src/recorder/stream_recorder/stream_recorder_impl2.cpp
                              src/recorder/stream_recorder/satellite_dns_resolution_manager.cpp
                              src/recorder/stream_recorder/satellite_endpoint_manager.cpp
                              src/recorder/stream_recorder/satellite_connection.cpp

--- a/src/common/BUILD
+++ b/src/common/BUILD
@@ -17,6 +17,13 @@ lightstep_cc_library(
 )
 
 lightstep_cc_library(
+    name = "atomic_unique_ptr_lib",
+    private_hdrs = [
+        "atomic_unique_ptr.h",
+    ],
+)
+
+lightstep_cc_library(
     name = "bipart_memory_stream_lib",
     private_hdrs = [
         "bipart_memory_stream.h",
@@ -59,6 +66,17 @@ lightstep_cc_library(
 )
 
 lightstep_cc_library(
+    name = "circular_buffer2_lib",
+    private_hdrs = [
+        "circular_buffer2.h",
+    ],
+    deps = [
+        ":circular_buffer_range_lib",
+        ":atomic_unique_ptr_lib",
+    ],
+)
+
+lightstep_cc_library(
     name = "chunk_circular_buffer_lib",
     private_hdrs = [
       "chunk_circular_buffer.h",
@@ -72,6 +90,13 @@ lightstep_cc_library(
         ":circular_buffer_lib",
         ":function_ref_lib",
         ":utility_lib",
+    ],
+)
+
+lightstep_cc_library(
+    name = "circular_buffer_range_lib",
+    private_hdrs = [
+        "circular_buffer_range.h",
     ],
 )
 

--- a/src/common/atomic_unique_ptr.h
+++ b/src/common/atomic_unique_ptr.h
@@ -36,9 +36,13 @@ class AtomicUniquePtr {
     }
   }
 
-  T* Get() noexcept { return ptr_; }
+  T* Get() const noexcept { return ptr_; }
 
-  const T* Get() const noexcept { return ptr_; }
+  T& operator*() const noexcept {
+    return *Get();
+  }
+
+  T* operator->() const noexcept { return Get(); }
 
  private:
   std::atomic<T*> ptr_{nullptr};

--- a/src/common/atomic_unique_ptr.h
+++ b/src/common/atomic_unique_ptr.h
@@ -38,9 +38,7 @@ class AtomicUniquePtr {
 
   T* Get() const noexcept { return ptr_; }
 
-  T& operator*() const noexcept {
-    return *Get();
-  }
+  T& operator*() const noexcept { return *Get(); }
 
   T* operator->() const noexcept { return Get(); }
 

--- a/src/common/atomic_unique_ptr.h
+++ b/src/common/atomic_unique_ptr.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+namespace lightstep {
+template <class T>
+class AtomicUniquePtr {
+ public:
+  AtomicUniquePtr() noexcept = default;
+
+  ~AtomicUniquePtr() noexcept { Reset(); }
+
+  bool IsNull() const noexcept { return ptr_ == nullptr; }
+
+  bool SwapIfNull(std::unique_ptr<T>& owner) noexcept {
+    auto ptr = owner.get();
+    T* expected = nullptr;
+    auto was_successful = ptr_.compare_exchange_weak(
+        expected, ptr, std::memory_order_release, std::memory_order_relaxed);
+    if (was_successful) {
+      owner.release();
+      return true;
+    }
+    return false;
+  }
+
+  void Swap(std::unique_ptr<T>& ptr) noexcept {
+    ptr.reset(ptr_.exchange(ptr.release()));
+  }
+
+  void Reset(T* ptr = nullptr) noexcept {
+    ptr = ptr_.exchange(ptr);
+    if (ptr != nullptr) {
+      delete ptr;
+    }
+  }
+
+  T* Get() noexcept { return ptr_; }
+
+  const T* Get() const noexcept { return ptr_; }
+
+ private:
+  std::atomic<T*> ptr_{nullptr};
+};
+}  // namespace lightstep

--- a/src/common/circular_buffer2.h
+++ b/src/common/circular_buffer2.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <atomic>
-#include <memory>
 #include <cstdint>
+#include <memory>
 
 #include "common/atomic_unique_ptr.h"
 #include "common/circular_buffer_range.h"
@@ -62,10 +62,10 @@ class CircularBuffer2 {
   size_t max_size() const noexcept { return capacity_ - 1; }
 
  private:
-   std::unique_ptr<AtomicUniquePtr<T>[]> data_;
-   size_t capacity_;
-   std::atomic<int64_t> head_{0};
-   std::atomic<int64_t> tail_{0};
+  std::unique_ptr<AtomicUniquePtr<T>[]> data_;
+  size_t capacity_;
+  std::atomic<int64_t> head_{0};
+  std::atomic<int64_t> tail_{0};
 
   CircularBufferRange<AtomicUniquePtr<T>> PeekImpl() noexcept {
     int64_t tail_index = tail_ % capacity_;
@@ -80,4 +80,4 @@ class CircularBuffer2 {
     return {data + tail_index, data + capacity_, data, data + head_index};
   }
 };
-} // namespace lightstep
+}  // namespace lightstep

--- a/src/common/circular_buffer2.h
+++ b/src/common/circular_buffer2.h
@@ -59,7 +59,35 @@ class CircularBuffer2 {
     return true;
   }
 
+  void Clear() noexcept {
+    Consume(
+        size(), [](CircularBufferRange<AtomicUniquePtr<T>> range) noexcept {
+          range.ForEach([](AtomicUniquePtr<T> & ptr) noexcept {
+            ptr.Reset();
+            return true;
+          });
+        });
+  }
+
   size_t max_size() const noexcept { return capacity_ - 1; }
+
+  bool empty() const noexcept { return head_ == tail_; }
+
+  size_t size() const noexcept {
+    uint64_t tail = tail_;
+    uint64_t head = head_;
+    assert(tail <= head);
+    return head - tail;
+  }
+  /**
+   * @return the number of elements consumed from the circular buffer.
+   */
+  int64_t consumption_count() const noexcept { return tail_; }
+
+  /**
+   * @return the number of elements added to the circular buffer.
+   */
+  int64_t production_count() const noexcept { return head_; }
 
  private:
   std::unique_ptr<AtomicUniquePtr<T>[]> data_;

--- a/src/common/circular_buffer2.h
+++ b/src/common/circular_buffer2.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+#include "common/atomic_unique_ptr.h"
+#include "common/circular_buffer_range.h"
+
+namespace lightstep {
+template <class T>
+class CircularBuffer2 {
+ public:
+  explicit CircularBuffer2(size_t max_size) noexcept
+      : data_{new AtomicUniquePtr<T>[max_size + 1]}, capacity_{max_size + 1} {}
+
+  CircularBufferRange<T> Peek() noexcept {
+    int tail = tail_;
+    int head = head_;
+    if (head == tail) {
+      return {};
+    }
+    auto data = data_.get();
+    if (tail < head) {
+      return {data + tail, data + head, nullptr, nullptr};
+    }
+    return {data + tail, data + capacity_, data, data + head};
+  }
+
+  template <class Callback>
+  void Consume(size_t n, Callback callback) noexcept {
+    assert(n <= size());
+    auto range = Peek().Take(n);
+    static_assert(noexcept(callback(range)), "callback cannot throw");
+    tail_ = (tail_ + n) % capacity_;
+    callback(range);
+  }
+
+  bool Add(std::unique_ptr<T>& ptr) noexcept {
+    while (true) {
+      int head = head_;
+      int tail = tail_;
+
+      // The circular buffer is full, so return false.
+      if ((head + 1) % capacity_ == tail) {
+        return false;
+      }
+
+      if (data_[head].SwapIfNull(ptr)) {
+        auto new_head = (head + 1) % capacity_;
+        auto expected_head = head;
+        if (head_.compare_exchange_weak(expected_head, new_head,
+                                        std::memory_order_release,
+                                        std::memory_order_relaxed)) {
+          // free the swapped out value
+          ptr.reset();
+
+          return true;
+        }
+
+        // If we reached this point (unlikely), it means that between the last
+        // iteration elements were added and then consumed from the circular
+        // buffer, so we undo the swap and attempt to add again.
+        data_[head].Swap(ptr);
+      }
+    }
+    return true;
+  }
+
+  size_t size() const noexcept {
+    int tail = tail_;
+    int head = head_;
+    if (tail <= head) {
+      return head - tail;
+    }
+    return capacity_ - (tail - head);
+  }
+
+ private:
+   std::unique_ptr<AtomicUniquePtr<T>[]> data_;
+   size_t capacity_;
+   std::atomic<int> head_{0};
+   std::atomic<int> tail_{0};
+};
+} // namespace lightstep

--- a/src/common/circular_buffer2.h
+++ b/src/common/circular_buffer2.h
@@ -49,7 +49,7 @@ class CircularBuffer2 {
   /**
    * Adds an element into the circular buffer.
    * @param ptr a pointer to the element to add
-   * @return true if the element successfully added; false, otherwise.
+   * @return true if the element was successfully added; false, otherwise.
    */
   bool Add(std::unique_ptr<T>& ptr) noexcept {
     while (true) {

--- a/src/common/circular_buffer_range.h
+++ b/src/common/circular_buffer_range.h
@@ -35,12 +35,18 @@ class CircularBufferRange {
                                std::distance(first2_, last2_));
   }
 
+  bool empty() const noexcept {
+    assert((first1_ != last1_) || (first2_ == last2_));
+    return first1_ == last1_;
+  }
+
   CircularBufferRange Take(size_t n) const noexcept {
     assert(n <= size());
-    if (static_cast<size_t>(std::distance(first1_, last1_)) >= n) {
+    auto size1 = std::distance(first1_, last1_);
+    if (static_cast<size_t>(size1) >= n) {
       return {first1_, first1_ + n, nullptr, nullptr};
     }
-    return {first1_, last1_, first2_, first2_ + n};
+    return {first1_, last1_, first2_, first2_ + (n - size1)};
   }
 
   operator CircularBufferRange<const T>() const noexcept {

--- a/src/common/circular_buffer_range.h
+++ b/src/common/circular_buffer_range.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cassert>
+#include <utility>
+#include <iterator>
+
+namespace lightstep {
+template <class T>
+class CircularBufferRange {
+ public:
+  CircularBufferRange() noexcept = default;
+
+  CircularBufferRange(T* first1, T* last1, T* first2, T* last2) noexcept
+      : first1_{first1}, last1_{last1}, first2_{first2}, last2_{last2} {}
+
+  template <class Callback>
+  bool ForEach(Callback callback) const
+      noexcept(noexcept(std::declval<Callback>()(std::declval<T>()))) {
+    for (auto iter = first1_; iter != last1_; ++iter) {
+      if (!callback(*iter)) {
+        return false;
+      }
+    }
+    for (auto iter = first2_; iter != last2_; ++iter) {
+      if (!callback(*iter)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  size_t size() const noexcept {
+    return static_cast<size_t>(std::distance(first1_, last1_) +
+                               std::distance(first2_, last2_));
+  }
+
+  CircularBufferRange Take(size_t n) const noexcept {
+    assert(n <= size());
+    if (std::distance(first1_, last1_) >= n) {
+      return {first1_, first1_ + n, nullptr, nullptr};
+    }
+    return {first1_, last1_, first2_, first2_ + n};
+  }
+
+ private:
+  T* first1_{nullptr};
+  T* last1_{nullptr};
+  T* first2_{nullptr};
+  T* last2_{nullptr};
+};
+}  // namespace lightstep

--- a/src/common/circular_buffer_range.h
+++ b/src/common/circular_buffer_range.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <cassert>
-#include <utility>
 #include <iterator>
 #include <type_traits>
+#include <utility>
 
 namespace lightstep {
 template <class T>

--- a/src/common/circular_buffer_range.h
+++ b/src/common/circular_buffer_range.h
@@ -6,6 +6,9 @@
 #include <utility>
 
 namespace lightstep {
+/**
+ * A non-owning view into a range of elements in a circular buffer.
+ */
 template <class T>
 class CircularBufferRange {
  public:
@@ -14,6 +17,15 @@ class CircularBufferRange {
   CircularBufferRange(T* first1, T* last1, T* first2, T* last2) noexcept
       : first1_{first1}, last1_{last1}, first2_{first2}, last2_{last2} {}
 
+  operator CircularBufferRange<const T>() const noexcept {
+    return {first1_, last1_, first2_, last2_};
+  }
+
+  /**
+   * Iterate over the elements in the range.
+   * @param callback the callback to call for each element
+   * @return true if we iterated over all elements
+   */
   template <class Callback>
   bool ForEach(Callback callback) const
       noexcept(noexcept(std::declval<Callback>()(std::declval<T&>()))) {
@@ -30,16 +42,27 @@ class CircularBufferRange {
     return true;
   }
 
+  /**
+   * @return the number of elements in the range
+   */
   size_t size() const noexcept {
     return static_cast<size_t>(std::distance(first1_, last1_) +
                                std::distance(first2_, last2_));
   }
 
+  /**
+   * @return true if the range is empty
+   */
   bool empty() const noexcept {
     assert((first1_ != last1_) || (first2_ == last2_));
     return first1_ == last1_;
   }
 
+  /**
+   * Return a subrange taken from the start of this range.
+   * @param n the number of element to take in the subrange
+   * @return a subrange of the first n elements in this range
+   */
   CircularBufferRange Take(size_t n) const noexcept {
     assert(n <= size());
     auto size1 = std::distance(first1_, last1_);
@@ -47,10 +70,6 @@ class CircularBufferRange {
       return {first1_, first1_ + n, nullptr, nullptr};
     }
     return {first1_, last1_, first2_, first2_ + (n - size1)};
-  }
-
-  operator CircularBufferRange<const T>() const noexcept {
-    return {first1_, last1_, first2_, last2_};
   }
 
  private:

--- a/src/common/circular_buffer_range.h
+++ b/src/common/circular_buffer_range.h
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <utility>
 #include <iterator>
+#include <type_traits>
 
 namespace lightstep {
 template <class T>
@@ -15,7 +16,7 @@ class CircularBufferRange {
 
   template <class Callback>
   bool ForEach(Callback callback) const
-      noexcept(noexcept(std::declval<Callback>()(std::declval<T>()))) {
+      noexcept(noexcept(std::declval<Callback>()(std::declval<T&>()))) {
     for (auto iter = first1_; iter != last1_; ++iter) {
       if (!callback(*iter)) {
         return false;
@@ -36,10 +37,14 @@ class CircularBufferRange {
 
   CircularBufferRange Take(size_t n) const noexcept {
     assert(n <= size());
-    if (std::distance(first1_, last1_) >= n) {
+    if (static_cast<size_t>(std::distance(first1_, last1_)) >= n) {
       return {first1_, first1_ + n, nullptr, nullptr};
     }
     return {first1_, last1_, first2_, first2_ + n};
+  }
+
+  operator CircularBufferRange<const T>() const noexcept {
+    return {first1_, last1_, first2_, last2_};
   }
 
  private:

--- a/src/recorder/stream_recorder/BUILD
+++ b/src/recorder/stream_recorder/BUILD
@@ -92,9 +92,12 @@ lightstep_cc_library(
         "stream_recorder2.cpp",
         "stream_recorder_impl.h",
         "stream_recorder_impl.cpp",
+        "stream_recorder_impl2.h",
+        "stream_recorder_impl2.cpp",
     ],
     deps = [
         "//src/common:chunk_circular_buffer_lib",
+        "//src/common:circular_buffer2_lib",
         "//src/common:logger_lib",
         "//src/common:noncopyable_lib",
         "//src/common:protobuf_lib",

--- a/src/recorder/stream_recorder/stream_recorder2.cpp
+++ b/src/recorder/stream_recorder/stream_recorder2.cpp
@@ -36,7 +36,7 @@ StreamRecorder2::StreamRecorder2(Logger& logger,
 void StreamRecorder2::RecordSpan(
     std::unique_ptr<SerializationChain>&& span) noexcept {
   span->AddFraming();
-  if(!span_buffer_.Add(span)) {
+  if (!span_buffer_.Add(span)) {
     logger_.Debug("Dropping span");
     metrics_.OnSpansDropped(1);
     span.reset();

--- a/src/recorder/stream_recorder/stream_recorder2.cpp
+++ b/src/recorder/stream_recorder/stream_recorder2.cpp
@@ -2,14 +2,32 @@
 
 namespace lightstep {
 //--------------------------------------------------------------------------------------------------
+// GetMetricsObserver
+//--------------------------------------------------------------------------------------------------
+static MetricsObserver& GetMetricsObserver(
+    LightStepTracerOptions& tracer_options) {
+  if (tracer_options.metrics_observer == nullptr) {
+    tracer_options.metrics_observer.reset(new MetricsObserver{});
+  }
+  return *tracer_options.metrics_observer;
+}
+
+//--------------------------------------------------------------------------------------------------
 // constructor
 //--------------------------------------------------------------------------------------------------
 StreamRecorder2::StreamRecorder2(Logger& logger,
                                  LightStepTracerOptions&& tracer_options,
-                                 StreamRecorderOptions&& recorder_options) {
-  (void)logger;
-  (void)tracer_options;
-  (void)recorder_options;
+                                 StreamRecorderOptions&& recorder_options)
+    : logger_{logger},
+      tracer_options_{std::move(tracer_options)},
+      recorder_options_{std::move(recorder_options)},
+      metrics_{GetMetricsObserver(tracer_options_)},
+      span_buffer_{tracer_options_.max_buffered_spans.value()} {
+  // If no MetricsObserver was provided, use a default one that does nothing.
+  if (tracer_options_.metrics_observer == nullptr) {
+    tracer_options_.metrics_observer.reset(new MetricsObserver{});
+  }
+  stream_recorder_impl_.reset(new StreamRecorderImpl2{*this});
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -18,15 +36,74 @@ StreamRecorder2::StreamRecorder2(Logger& logger,
 void StreamRecorder2::RecordSpan(
     std::unique_ptr<SerializationChain>&& span) noexcept {
   span->AddFraming();
-  (void)span;
+  if(!span_buffer_.Add(span)) {
+    logger_.Debug("Dropping span");
+    metrics_.OnSpansDropped(1);
+    span.reset();
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
 // FlushWithTimeout
 //--------------------------------------------------------------------------------------------------
 bool StreamRecorder2::FlushWithTimeout(
-    std::chrono::system_clock::duration timeout) noexcept {
-  (void)timeout;
-  return true;
+    std::chrono::system_clock::duration timeout) noexcept try {
+  auto num_spans_produced = span_buffer_.production_count();
+  std::unique_lock<std::mutex> lock{flush_mutex_};
+  if (num_spans_consumed_ >= num_spans_produced) {
+    return true;
+  }
+  ++pending_flush_counter_;
+  flush_condition_variable_.wait_for(lock, timeout, [this, num_spans_produced] {
+    return exit_ || num_spans_consumed_ >= num_spans_produced;
+  });
+  return num_spans_consumed_ >= num_spans_produced;
+} catch (const std::exception& e) {
+  logger_.Error("StreamRecorder::FlushWithTimeout failed: ", e.what());
+  return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+// PrepareForFork
+//--------------------------------------------------------------------------------------------------
+void StreamRecorder2::PrepareForFork() noexcept {
+  // We don't want parent and child processes to share sockets so close any open
+  // connections.
+  stream_recorder_impl_.reset(nullptr);
+}
+
+//--------------------------------------------------------------------------------------------------
+// OnForkedParent
+//--------------------------------------------------------------------------------------------------
+void StreamRecorder2::OnForkedParent() noexcept {
+  stream_recorder_impl_.reset(new StreamRecorderImpl2{*this});
+}
+
+//--------------------------------------------------------------------------------------------------
+// OnForkedChild
+//--------------------------------------------------------------------------------------------------
+void StreamRecorder2::OnForkedChild() noexcept {
+  // Clear any buffered data since it will already be recorded from the parent
+  // process.
+  metrics_.ConsumeDroppedSpans();
+  span_buffer_.Clear();
+  num_spans_consumed_ = span_buffer_.production_count();
+  pending_flush_counter_ = 0;
+
+  stream_recorder_impl_.reset(new StreamRecorderImpl2{*this});
+}
+
+//--------------------------------------------------------------------------------------------------
+// Poll
+//--------------------------------------------------------------------------------------------------
+void StreamRecorder2::Poll() noexcept {
+  auto num_spans_consumed = span_buffer_.consumption_count();
+  if (num_spans_consumed > num_spans_consumed_) {
+    {
+      std::lock_guard<std::mutex> lock_guard{flush_mutex_};
+      num_spans_consumed_ = num_spans_consumed;
+    }
+    flush_condition_variable_.notify_all();
+  }
 }
 }  // namespace lightstep

--- a/src/recorder/stream_recorder/stream_recorder2.h
+++ b/src/recorder/stream_recorder/stream_recorder2.h
@@ -32,6 +32,7 @@ class StreamRecorder2 : public ForkAwareRecorder, private Noncopyable {
    * Checks whether any threads blocked on flush calls can be resumed.
    */
   void Poll() noexcept;
+
   /**
    * Gets the pending flush count and resets the counter.
    * @return the pending flush count.

--- a/src/recorder/stream_recorder/stream_recorder2.h
+++ b/src/recorder/stream_recorder/stream_recorder2.h
@@ -26,6 +26,8 @@ class StreamRecorder2 : public ForkAwareRecorder, private Noncopyable {
       Logger& logger, LightStepTracerOptions&& tracer_options,
       StreamRecorderOptions&& recorder_options = StreamRecorderOptions{});
 
+  ~StreamRecorder2() noexcept override;
+
   /**
    * Checks whether any threads blocked on flush calls can be resumed.
    */

--- a/src/recorder/stream_recorder/stream_recorder2.h
+++ b/src/recorder/stream_recorder/stream_recorder2.h
@@ -1,9 +1,19 @@
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+#include "stream_recorder_impl2.h"
+
 #include "common/noncopyable.h"
 #include "common/serialization_chain.h"
+#include "common/circular_buffer2.h"
 #include "recorder/fork_aware_recorder.h"
 #include "recorder/stream_recorder/stream_recorder_options.h"
+#include "recorder/stream_recorder/stream_recorder_metrics.h"
 
 namespace lightstep {
 /**
@@ -16,12 +26,74 @@ class StreamRecorder2 : public ForkAwareRecorder, private Noncopyable {
       Logger& logger, LightStepTracerOptions&& tracer_options,
       StreamRecorderOptions&& recorder_options = StreamRecorderOptions{});
 
+  /**
+   * Checks whether any threads blocked on flush calls can be resumed.
+   */
+  void Poll() noexcept;
+  /**
+   * Gets the pending flush count and resets the counter.
+   * @return the pending flush count.
+   */
+  int ConsumePendingFlushCount() noexcept {
+    return pending_flush_counter_.exchange(0);
+  }
+
+  /**
+   * @return the associated Logger.
+   */
+  Logger& logger() const noexcept { return logger_; }
+
+  /**
+   * @return the associated LightStepTracerOptions
+   */
+  const LightStepTracerOptions& tracer_options() const noexcept {
+    return tracer_options_;
+  }
+
+  /**
+   * @return the associated StreamRecorderOptions.
+   */
+  const StreamRecorderOptions& recorder_options() const noexcept {
+    return recorder_options_;
+  }
+
+  /**
+   * @return the associated StreamRecorderMetrics.
+   */
+  StreamRecorderMetrics& metrics() noexcept { return metrics_; }
+
+  /**
+   * @return the associated span buffer.
+   */
+  CircularBuffer2<SerializationChain>& span_buffer() noexcept { return span_buffer_; }
+
   // Recorder
   void RecordSpan(std::unique_ptr<SerializationChain>&& span) noexcept override;
 
   bool FlushWithTimeout(
       std::chrono::system_clock::duration timeout) noexcept override;
 
+  // ForkAwareRecorder
+  void PrepareForFork() noexcept override;
+
+  void OnForkedParent() noexcept override;
+
+  void OnForkedChild() noexcept override;
+
  private:
+  Logger& logger_;
+  LightStepTracerOptions tracer_options_;
+  StreamRecorderOptions recorder_options_;
+  StreamRecorderMetrics metrics_;
+  CircularBuffer2<SerializationChain> span_buffer_;
+
+  std::atomic<bool> exit_{false};
+
+  std::mutex flush_mutex_;
+  std::condition_variable flush_condition_variable_;
+  std::atomic<int> pending_flush_counter_{0};
+  int64_t num_spans_consumed_{0};
+
+  std::unique_ptr<StreamRecorderImpl2> stream_recorder_impl_;
 };
 }  // namespace lightstep

--- a/src/recorder/stream_recorder/stream_recorder2.h
+++ b/src/recorder/stream_recorder/stream_recorder2.h
@@ -8,12 +8,12 @@
 
 #include "stream_recorder_impl2.h"
 
+#include "common/circular_buffer2.h"
 #include "common/noncopyable.h"
 #include "common/serialization_chain.h"
-#include "common/circular_buffer2.h"
 #include "recorder/fork_aware_recorder.h"
-#include "recorder/stream_recorder/stream_recorder_options.h"
 #include "recorder/stream_recorder/stream_recorder_metrics.h"
+#include "recorder/stream_recorder/stream_recorder_options.h"
 
 namespace lightstep {
 /**
@@ -65,7 +65,9 @@ class StreamRecorder2 : public ForkAwareRecorder, private Noncopyable {
   /**
    * @return the associated span buffer.
    */
-  CircularBuffer2<SerializationChain>& span_buffer() noexcept { return span_buffer_; }
+  CircularBuffer2<SerializationChain>& span_buffer() noexcept {
+    return span_buffer_;
+  }
 
   // Recorder
   void RecordSpan(std::unique_ptr<SerializationChain>&& span) noexcept override;

--- a/src/recorder/stream_recorder/stream_recorder_impl2.cpp
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.cpp
@@ -18,14 +18,13 @@ StreamRecorderImpl2::StreamRecorderImpl2(StreamRecorder2& stream_recorder)
       flush_timer_{
           event_base_, stream_recorder_.recorder_options().flushing_period,
           MakeTimerCallback<StreamRecorderImpl2, &StreamRecorderImpl2::Flush>(),
-          static_cast<void*>(this)}
-/* , */
+          static_cast<void*>(this)} /* , */
 /*       streamer_{stream_recorder_.logger(), */
 /*                 event_base_, */
 /*                 stream_recorder_.tracer_options(), */
 /*                 stream_recorder_.recorder_options(), */
 /*                 stream_recorder_.metrics(), */
-/*                 stream_recorder_.span_buffer()} */ 
+/*                 stream_recorder_.span_buffer()} */
 {
   thread_ = std::thread{&StreamRecorderImpl2::Run, this};
 }
@@ -97,4 +96,4 @@ void StreamRecorderImpl2::Flush() noexcept try {
 } catch (const std::exception& e) {
   stream_recorder_.logger().Error("StreamRecorder::Flush failed: ", e.what());
 }
-} // namespace lightstep
+}  // namespace lightstep

--- a/src/recorder/stream_recorder/stream_recorder_impl2.cpp
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.cpp
@@ -1,0 +1,100 @@
+#include "stream_recorder_impl2.h"
+
+#include "recorder/stream_recorder/stream_recorder2.h"
+
+namespace lightstep {
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+StreamRecorderImpl2::StreamRecorderImpl2(StreamRecorder2& stream_recorder)
+    : stream_recorder_{stream_recorder},
+      early_flush_marker_{static_cast<size_t>(
+          stream_recorder_.recorder_options().max_span_buffer_bytes *
+          stream_recorder_.recorder_options().early_flush_threshold)},
+      poll_timer_{
+          event_base_, stream_recorder_.recorder_options().polling_period,
+          MakeTimerCallback<StreamRecorderImpl2, &StreamRecorderImpl2::Poll>(),
+          static_cast<void*>(this)},
+      flush_timer_{
+          event_base_, stream_recorder_.recorder_options().flushing_period,
+          MakeTimerCallback<StreamRecorderImpl2, &StreamRecorderImpl2::Flush>(),
+          static_cast<void*>(this)}
+/* , */
+/*       streamer_{stream_recorder_.logger(), */
+/*                 event_base_, */
+/*                 stream_recorder_.tracer_options(), */
+/*                 stream_recorder_.recorder_options(), */
+/*                 stream_recorder_.metrics(), */
+/*                 stream_recorder_.span_buffer()} */ 
+{
+  thread_ = std::thread{&StreamRecorderImpl2::Run, this};
+}
+
+//--------------------------------------------------------------------------------------------------
+// destructor
+//--------------------------------------------------------------------------------------------------
+StreamRecorderImpl2::~StreamRecorderImpl2() noexcept {
+  exit_ = true;
+  thread_.join();
+}
+
+//--------------------------------------------------------------------------------------------------
+// Run
+//--------------------------------------------------------------------------------------------------
+void StreamRecorderImpl2::Run() noexcept try {
+  event_base_.Dispatch();
+} catch (const std::exception& e) {
+  stream_recorder_.logger().Error("StreamRecorder::Run failed: ", e.what());
+}
+
+//--------------------------------------------------------------------------------------------------
+// Poll
+//--------------------------------------------------------------------------------------------------
+void StreamRecorderImpl2::Poll() noexcept {
+  if (exit_) {
+    try {
+      // Attempt to flush any pending spans before shutting down.
+      //
+      // Note: Flush is non-blocking so we can do this without causing an
+      // unacceptable delay to process termination.
+      Flush();
+
+      // Shut down the event loop.
+      return event_base_.LoopBreak();
+    } catch (const std::exception& e) {
+      stream_recorder_.logger().Error(
+          "StreamRecorder: failed to break out of event loop: ", e.what());
+      std::terminate();
+    }
+  }
+
+  auto pending_flush_count = stream_recorder_.ConsumePendingFlushCount();
+  if (pending_flush_count > 0 ||
+      stream_recorder_.span_buffer().size() > early_flush_marker_) {
+    Flush();
+  }
+
+  stream_recorder_.Poll();
+}
+
+//--------------------------------------------------------------------------------------------------
+// Flush
+//--------------------------------------------------------------------------------------------------
+void StreamRecorderImpl2::Flush() noexcept try {
+  auto& span_buffer = stream_recorder_.span_buffer();
+  auto allotment = span_buffer.Peek();
+  span_buffer.Consume(
+      allotment.size(),
+      [](CircularBufferRange<AtomicUniquePtr<SerializationChain>>
+             range) noexcept {
+        range.ForEach([](AtomicUniquePtr<SerializationChain> & span) noexcept {
+          span.Reset();
+          return true;
+        });
+      });
+  flush_timer_.Reset();
+  stream_recorder_.metrics().OnFlush();
+} catch (const std::exception& e) {
+  stream_recorder_.logger().Error("StreamRecorder::Flush failed: ", e.what());
+}
+} // namespace lightstep

--- a/src/recorder/stream_recorder/stream_recorder_impl2.cpp
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.cpp
@@ -18,14 +18,7 @@ StreamRecorderImpl2::StreamRecorderImpl2(StreamRecorder2& stream_recorder)
       flush_timer_{
           event_base_, stream_recorder_.recorder_options().flushing_period,
           MakeTimerCallback<StreamRecorderImpl2, &StreamRecorderImpl2::Flush>(),
-          static_cast<void*>(this)} /* , */
-/*       streamer_{stream_recorder_.logger(), */
-/*                 event_base_, */
-/*                 stream_recorder_.tracer_options(), */
-/*                 stream_recorder_.recorder_options(), */
-/*                 stream_recorder_.metrics(), */
-/*                 stream_recorder_.span_buffer()} */
-{
+          static_cast<void*>(this)} {
   thread_ = std::thread{&StreamRecorderImpl2::Run, this};
 }
 

--- a/src/recorder/stream_recorder/stream_recorder_impl2.h
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.h
@@ -42,4 +42,4 @@ class StreamRecorderImpl2 : private Noncopyable {
 
   void Flush() noexcept;
 };
-} // namespace lightstep
+}  // namespace lightstep

--- a/src/recorder/stream_recorder/stream_recorder_impl2.h
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <atomic>
+#include <thread>
+
+#include "common/noncopyable.h"
+#include "network/event_base.h"
+#include "network/timer_event.h"
+
+namespace lightstep {
+class StreamRecorder2;
+
+/**
+ * Implements the part of StreamRecorder that manages the recording thread and
+ * satellite connections.
+ *
+ * This functionality is broken out into a separate class so that the resources
+ * can be brought down and resumed so as to support forking.
+ */
+class StreamRecorderImpl2 : private Noncopyable {
+ public:
+  explicit StreamRecorderImpl2(StreamRecorder2& stream_recorder);
+
+  ~StreamRecorderImpl2() noexcept;
+
+ private:
+  StreamRecorder2& stream_recorder_;
+
+  EventBase event_base_;
+  size_t early_flush_marker_;
+  TimerEvent poll_timer_;
+  TimerEvent flush_timer_;
+
+  /* SatelliteStreamer streamer_; */
+
+  std::thread thread_;
+  std::atomic<bool> exit_{false};
+
+  void Run() noexcept;
+
+  void Poll() noexcept;
+
+  void Flush() noexcept;
+};
+} // namespace lightstep

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -52,6 +52,7 @@ lightstep_catch_test(
     srcs = [
         "circular_buffer2_test.cpp",
     ],
+    linkopts = ["-pthread"],
     deps = [
         "//src/common:circular_buffer2_lib",
     ],

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -18,6 +18,16 @@ lightstep_catch_test(
 )
 
 lightstep_catch_test(
+    name = "atomic_unique_ptr_test",
+    srcs = [
+        "atomic_unique_ptr_test.cpp",
+    ],
+    deps = [
+        "//src/common:atomic_unique_ptr_lib",
+    ],
+)
+
+lightstep_catch_test(
     name = "bipart_memory_stream_test",
     srcs = [
         "bipart_memory_stream_test.cpp",
@@ -34,6 +44,26 @@ lightstep_catch_test(
     ],
     deps = [
         "//src/common:circular_buffer_lib",
+    ],
+)
+
+lightstep_catch_test(
+    name = "circular_buffer2_test",
+    srcs = [
+        "circular_buffer2_test.cpp",
+    ],
+    deps = [
+        "//src/common:circular_buffer2_lib",
+    ],
+)
+
+lightstep_catch_test(
+    name = "circular_buffer_range_test",
+    srcs = [
+        "circular_buffer_range_test.cpp",
+    ],
+    deps = [
+        "//src/common:circular_buffer_range_lib",
     ],
 )
 

--- a/test/common/atomic_unique_ptr_test.cpp
+++ b/test/common/atomic_unique_ptr_test.cpp
@@ -11,7 +11,7 @@ TEST_CASE("AtomicUniquePtr") {
     std::unique_ptr<int> x{new int{33}};
     REQUIRE(ptr.SwapIfNull(x));
     REQUIRE(x == nullptr);
-    REQUIRE(*ptr.Get() == 33);
+    REQUIRE(*ptr == 33);
   }
 
   SECTION("SwapIfNull does nothing if AtomicUniquePtr is non-null") {
@@ -20,7 +20,7 @@ TEST_CASE("AtomicUniquePtr") {
     REQUIRE(!ptr.SwapIfNull(x));
     REQUIRE(x != nullptr);
     REQUIRE(*x == 33);
-    REQUIRE(*ptr.Get() == 11);
+    REQUIRE(*ptr == 11);
   }
 
   SECTION("Swap always swaps an AtomicUniquePtr") {
@@ -30,6 +30,6 @@ TEST_CASE("AtomicUniquePtr") {
     REQUIRE(!ptr.IsNull());
     REQUIRE(x != nullptr);
     REQUIRE(*x == 11);
-    REQUIRE(*ptr.Get() == 33);
+    REQUIRE(*ptr == 33);
   }
 }

--- a/test/common/atomic_unique_ptr_test.cpp
+++ b/test/common/atomic_unique_ptr_test.cpp
@@ -1,0 +1,35 @@
+#include "common/atomic_unique_ptr.h"
+
+#include "3rd_party/catch2/catch.hpp"
+using namespace lightstep;
+
+TEST_CASE("AtomicUniquePtr") {
+  AtomicUniquePtr<int> ptr;
+  REQUIRE(ptr.IsNull());
+
+  SECTION("SwapIfNull swaps an AtomicUniquePtr is null") {
+    std::unique_ptr<int> x{new int{33}};
+    REQUIRE(ptr.SwapIfNull(x));
+    REQUIRE(x == nullptr);
+    REQUIRE(*ptr.Get() == 33);
+  }
+
+  SECTION("SwapIfNull does nothing if AtomicUniquePtr is non-null") {
+    ptr.Reset(new int{11});
+    std::unique_ptr<int> x{new int{33}};
+    REQUIRE(!ptr.SwapIfNull(x));
+    REQUIRE(x != nullptr);
+    REQUIRE(*x == 33);
+    REQUIRE(*ptr.Get() == 11);
+  }
+
+  SECTION("Swap always swaps an AtomicUniquePtr") {
+    ptr.Reset(new int{11});
+    std::unique_ptr<int> x{new int{33}};
+    ptr.Swap(x);
+    REQUIRE(!ptr.IsNull());
+    REQUIRE(x != nullptr);
+    REQUIRE(*x == 11);
+    REQUIRE(*ptr.Get() == 33);
+  }
+}

--- a/test/common/circular_buffer2_test.cpp
+++ b/test/common/circular_buffer2_test.cpp
@@ -1,7 +1,66 @@
 #include "common/circular_buffer2.h"
 
+#include <random>
+#include <thread>
+
 #include "3rd_party/catch2/catch.hpp"
 using namespace lightstep;
+
+static thread_local std::mt19937 RandomNumberGenerator{
+    std::random_device{}()};
+
+static void GenerateRandomNumbers(CircularBuffer2<uint32_t>& buffer,
+                                  std::vector<uint32_t>& numbers, int n) {
+  for (int i=0; i<n; ++i) {
+    auto value = static_cast<uint32_t>(RandomNumberGenerator());
+    std::unique_ptr<uint32_t> x{new uint32_t{value}};
+    if (buffer.Add(x)) {
+      numbers.push_back(value);
+    }
+  }
+}
+
+static void RunNumberProducers(CircularBuffer2<uint32_t>& buffer,
+                               std::vector<uint32_t>& numbers, int num_threads,
+                               int n) {
+  std::vector<std::vector<uint32_t>> thread_numbers(num_threads);
+  std::vector<std::thread> threads(num_threads);
+  for (int thread_index = 0; thread_index < num_threads; ++thread_index) {
+    threads[thread_index] =
+        std::thread{GenerateRandomNumbers, std::ref(buffer),
+                    std::ref(thread_numbers[thread_index]), n};
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  for (int thread_index = 0; thread_index < num_threads; ++thread_index) {
+    numbers.insert(numbers.end(), thread_numbers[thread_index].begin(),
+                   thread_numbers[thread_index].end());
+  }
+}
+
+void RunNumberConsumer(CircularBuffer2<uint32_t>& buffer,
+                       std::atomic<bool>& exit,
+                       std::vector<uint32_t>& numbers) {
+  while (true) {
+    auto allotment = buffer.Peek();
+    if (exit && allotment.empty()) {
+      return;
+    }
+    auto n = std::uniform_int_distribution<size_t>{
+        0, allotment.size()}(RandomNumberGenerator);
+    buffer.Consume(
+        n, [&](CircularBufferRange<AtomicUniquePtr<uint32_t>> range) noexcept {
+          REQUIRE(range.size() == n);
+          range.ForEach([&](AtomicUniquePtr<uint32_t> & ptr) noexcept {
+            REQUIRE(!ptr.IsNull());
+            numbers.push_back(*ptr);
+            ptr.Reset();
+            return true;
+          });
+        });
+  }
+}
 
 TEST_CASE("CircularBuffer") {
   CircularBuffer2<int> buffer{10};
@@ -43,5 +102,27 @@ TEST_CASE("CircularBuffer") {
       });
     });
     REQUIRE(count == 5);
+  }
+}
+
+TEST_CASE("Verify CircularBuffer behaves correctly through simulation") {
+  const int num_producer_threads = 4;
+  const int n = 25000;
+  for (size_t max_size : {1, 2, 10, 50, 100, 1000}) {
+    CircularBuffer2<uint32_t> buffer{max_size};
+    std::vector<uint32_t> producer_numbers;
+    std::vector<uint32_t> consumer_numbers;
+    auto producers =
+        std::thread{RunNumberProducers, std::ref(buffer),
+                    std::ref(producer_numbers), num_producer_threads, n};
+    std::atomic<bool> exit{false};
+    auto consumer = std::thread{RunNumberConsumer, std::ref(buffer),
+                                std::ref(exit), std::ref(consumer_numbers)};
+    producers.join();
+    exit = true;
+    consumer.join();
+    std::sort(producer_numbers.begin(), producer_numbers.end());
+    std::sort(consumer_numbers.begin(), consumer_numbers.end());
+    REQUIRE(producer_numbers == consumer_numbers);
   }
 }

--- a/test/common/circular_buffer2_test.cpp
+++ b/test/common/circular_buffer2_test.cpp
@@ -76,6 +76,14 @@ TEST_CASE("CircularBuffer") {
     });
   }
 
+  SECTION("We can clear a circular buffer") {
+    std::unique_ptr<int> x{new int{11}};
+    REQUIRE(buffer.Add(x));
+    REQUIRE(x == nullptr);
+    buffer.Clear();
+    REQUIRE(buffer.empty());
+  }
+
   SECTION("If CircularBuffer is full, Add fails") {
     for (int i = 0; i < static_cast<int>(buffer.max_size()); ++i) {
       std::unique_ptr<int> x{new int{i}};

--- a/test/common/circular_buffer2_test.cpp
+++ b/test/common/circular_buffer2_test.cpp
@@ -4,6 +4,44 @@
 using namespace lightstep;
 
 TEST_CASE("CircularBuffer") {
-  CircularBuffer2<int> buffer{100};
-  (void)buffer;
+  CircularBuffer2<int> buffer{10};
+
+  SECTION("We can add values into a circular buffer") {
+    std::unique_ptr<int> x{new int{11}};
+    REQUIRE(buffer.Add(x));
+    REQUIRE(x == nullptr);
+    auto range = buffer.Peek();
+    REQUIRE(range.size() == 1);
+    range.ForEach([] (const AtomicUniquePtr<int>& y) {
+        REQUIRE(*y == 11);
+        return true;
+    });
+  }
+
+  SECTION("If CircularBuffer is full, Add fails") {
+    for (int i = 0; i < static_cast<int>(buffer.max_size()); ++i) {
+      std::unique_ptr<int> x{new int{i}};
+      REQUIRE(buffer.Add(x));
+    }
+    std::unique_ptr<int> x{new int{33}};
+    REQUIRE(!buffer.Add(x));
+    REQUIRE(x != nullptr);
+    REQUIRE(*x == 33);
+  }
+
+  SECTION("We can consume elements out of CircularBuffer") {
+    for (int i = 0; i < static_cast<int>(buffer.max_size()); ++i) {
+      std::unique_ptr<int> x{new int{i}};
+      REQUIRE(buffer.Add(x));
+    }
+    int count = 0;
+    buffer.Consume(5, [&] (CircularBufferRange<AtomicUniquePtr<int>> range) noexcept {
+      range.ForEach([&] (AtomicUniquePtr<int>& ptr) {
+          REQUIRE(*ptr == count++);
+          ptr.Reset();
+          return true;
+      });
+    });
+    REQUIRE(count == 5);
+  }
 }

--- a/test/common/circular_buffer2_test.cpp
+++ b/test/common/circular_buffer2_test.cpp
@@ -6,12 +6,11 @@
 #include "3rd_party/catch2/catch.hpp"
 using namespace lightstep;
 
-static thread_local std::mt19937 RandomNumberGenerator{
-    std::random_device{}()};
+static thread_local std::mt19937 RandomNumberGenerator{std::random_device{}()};
 
 static void GenerateRandomNumbers(CircularBuffer2<uint32_t>& buffer,
                                   std::vector<uint32_t>& numbers, int n) {
-  for (int i=0; i<n; ++i) {
+  for (int i = 0; i < n; ++i) {
     auto value = static_cast<uint32_t>(RandomNumberGenerator());
     std::unique_ptr<uint32_t> x{new uint32_t{value}};
     if (buffer.Add(x)) {
@@ -71,9 +70,9 @@ TEST_CASE("CircularBuffer") {
     REQUIRE(x == nullptr);
     auto range = buffer.Peek();
     REQUIRE(range.size() == 1);
-    range.ForEach([] (const AtomicUniquePtr<int>& y) {
-        REQUIRE(*y == 11);
-        return true;
+    range.ForEach([](const AtomicUniquePtr<int>& y) {
+      REQUIRE(*y == 11);
+      return true;
     });
   }
 
@@ -94,13 +93,14 @@ TEST_CASE("CircularBuffer") {
       REQUIRE(buffer.Add(x));
     }
     int count = 0;
-    buffer.Consume(5, [&] (CircularBufferRange<AtomicUniquePtr<int>> range) noexcept {
-      range.ForEach([&] (AtomicUniquePtr<int>& ptr) {
-          REQUIRE(*ptr == count++);
-          ptr.Reset();
-          return true;
-      });
-    });
+    buffer.Consume(
+        5, [&](CircularBufferRange<AtomicUniquePtr<int>> range) noexcept {
+          range.ForEach([&](AtomicUniquePtr<int>& ptr) {
+            REQUIRE(*ptr == count++);
+            ptr.Reset();
+            return true;
+          });
+        });
     REQUIRE(count == 5);
   }
 }

--- a/test/common/circular_buffer2_test.cpp
+++ b/test/common/circular_buffer2_test.cpp
@@ -1,0 +1,9 @@
+#include "common/circular_buffer2.h"
+
+#include "3rd_party/catch2/catch.hpp"
+using namespace lightstep;
+
+TEST_CASE("CircularBuffer") {
+  CircularBuffer2<int> buffer{100};
+  (void)buffer;
+}

--- a/test/common/circular_buffer_range_test.cpp
+++ b/test/common/circular_buffer_range_test.cpp
@@ -1,0 +1,41 @@
+#include "common/circular_buffer_range.h"
+
+#include <iterator>
+
+#include "3rd_party/catch2/catch.hpp"
+using namespace lightstep;
+
+TEST_CASE("CircularBufferRange") {
+  int array1[] = {1, 2, 3, 4};
+  int array2[] = {5, 6, 7};
+  CircularBufferRange<int> range{std::begin(array1), std::end(array1),
+                                 std::begin(array2), std::end(array2)};
+
+  SECTION("We can iterate over elements of a CircularBufferRange") {
+    int x = 0;
+    range.ForEach([&](int y) {
+      REQUIRE(++x == y);
+      return true;
+    });
+    REQUIRE(x == 7);
+  }
+
+  SECTION("We can bail out of iteration over a CircularBufferRange") {
+    int x = 0;
+    range.ForEach([&](int y) {
+      REQUIRE(++x == y);
+      return false;
+    });
+    REQUIRE(x == 1);
+
+    x = 0;
+    range.ForEach([&](int y) {
+      REQUIRE(++x == y);
+      if (y == 5) {
+        return false;
+      }
+      return true;
+    });
+    REQUIRE(x == 5);
+  }
+}

--- a/test/common/circular_buffer_range_test.cpp
+++ b/test/common/circular_buffer_range_test.cpp
@@ -31,10 +31,7 @@ TEST_CASE("CircularBufferRange") {
     x = 0;
     range.ForEach([&](int y) {
       REQUIRE(++x == y);
-      if (y == 5) {
-        return false;
-      }
-      return true;
+      return y != 5;
     });
     REQUIRE(x == 5);
   }

--- a/test/common/circular_buffer_range_test.cpp
+++ b/test/common/circular_buffer_range_test.cpp
@@ -38,4 +38,16 @@ TEST_CASE("CircularBufferRange") {
     });
     REQUIRE(x == 5);
   }
+
+  SECTION(
+      "We can implicitly convert a non-const CircularBufferRange to a const "
+      "one") {
+    CircularBufferRange<const int> range2{range};
+    int x = 0;
+    range2.ForEach([&](int y) {
+      REQUIRE(++x == y);
+      return true;
+    });
+    REQUIRE(x == 7);
+  }
 }


### PR DESCRIPTION
Introduces CircularBuffer2.
CircularBuffer is used to manage varying sized allocations into a region of contiguous memory. CircularBuffer2 manages pointers where the allocations are made externally.
CircularBuffer will be removed.