### PR TITLE
Timestamp optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ set(LIGHTSTEP_SRCS src/common/utility.cpp
                    src/common/random_traverser.cpp
                    src/common/serialization.cpp
                    src/common/serialization_chain.cpp
+                   src/common/timestamp.cpp
                    src/recorder/report_builder.cpp
                    src/recorder/auto_recorder.cpp
                    src/recorder/fork_aware_recorder.cpp

--- a/src/common/BUILD
+++ b/src/common/BUILD
@@ -255,3 +255,12 @@ lightstep_cc_library(
     ],
 )
 
+lightstep_cc_library(
+    name = "timestamp_lib",
+    private_hdrs = [
+        "timestamp.h",
+    ],
+    srcs = [
+        "timestamp.cpp",
+    ],
+)

--- a/src/common/timestamp.cpp
+++ b/src/common/timestamp.cpp
@@ -48,4 +48,4 @@ std::chrono::steady_clock::time_point ToSteadyTimestamp(
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(
           time_since_epoch)};
 }
-} // namespace lightstep
+}  // namespace lightstep

--- a/src/common/timestamp.cpp
+++ b/src/common/timestamp.cpp
@@ -28,9 +28,9 @@ int64_t ComputeSystemSteadyTimestampDelta() noexcept {
 //--------------------------------------------------------------------------------------------------
 std::chrono::system_clock::time_point ToSystemTimestamp(
     int64_t timestamp_delta,
-    std::chrono::steady_clock::time_point steady_time) noexcept {
+    std::chrono::steady_clock::time_point steady_timestamp) noexcept {
   auto time_since_epoch = std::chrono::nanoseconds{
-      ComputeNanosecondsSinceEpoch(steady_time) + timestamp_delta};
+      ComputeNanosecondsSinceEpoch(steady_timestamp) + timestamp_delta};
   return std::chrono::system_clock::time_point{
       std::chrono::duration_cast<std::chrono::system_clock::duration>(
           time_since_epoch)};
@@ -41,9 +41,9 @@ std::chrono::system_clock::time_point ToSystemTimestamp(
 //--------------------------------------------------------------------------------------------------
 std::chrono::steady_clock::time_point ToSteadyTimestamp(
     int64_t timestamp_delta,
-    std::chrono::system_clock::time_point system_time) noexcept {
+    std::chrono::system_clock::time_point system_timestamp) noexcept {
   auto time_since_epoch = std::chrono::nanoseconds{
-      ComputeNanosecondsSinceEpoch(system_time) - timestamp_delta};
+      ComputeNanosecondsSinceEpoch(system_timestamp) - timestamp_delta};
   return std::chrono::steady_clock::time_point{
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(
           time_since_epoch)};

--- a/src/common/timestamp.cpp
+++ b/src/common/timestamp.cpp
@@ -1,0 +1,51 @@
+#include "common/timestamp.h"
+
+namespace lightstep {
+//--------------------------------------------------------------------------------------------------
+// ComputeNanosecondsSinceEpoch
+//--------------------------------------------------------------------------------------------------
+template <class Clock, class Duration>
+static int64_t ComputeNanosecondsSinceEpoch(
+    std::chrono::time_point<Clock, Duration> time_point) noexcept {
+  return static_cast<int64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          time_point.time_since_epoch())
+          .count());
+}
+
+//--------------------------------------------------------------------------------------------------
+// ComputeSystemSteadyTimestampDelta
+//--------------------------------------------------------------------------------------------------
+int64_t ComputeSystemSteadyTimestampDelta() noexcept {
+  auto steady_now = std::chrono::steady_clock::now();
+  auto system_now = std::chrono::system_clock::now();
+  return ComputeNanosecondsSinceEpoch(system_now) -
+         ComputeNanosecondsSinceEpoch(steady_now);
+}
+
+//--------------------------------------------------------------------------------------------------
+// ToSystemTimestamp
+//--------------------------------------------------------------------------------------------------
+std::chrono::system_clock::time_point ToSystemTimestamp(
+    int64_t timestamp_delta,
+    std::chrono::steady_clock::time_point steady_time) noexcept {
+  auto time_since_epoch = std::chrono::nanoseconds{
+      ComputeNanosecondsSinceEpoch(steady_time) + timestamp_delta};
+  return std::chrono::system_clock::time_point{
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(
+          time_since_epoch)};
+}
+
+//--------------------------------------------------------------------------------------------------
+// ToSteadyTimestamp
+//--------------------------------------------------------------------------------------------------
+std::chrono::steady_clock::time_point ToSteadyTimestamp(
+    int64_t timestamp_delta,
+    std::chrono::system_clock::time_point system_time) noexcept {
+  auto time_since_epoch = std::chrono::nanoseconds{
+      ComputeNanosecondsSinceEpoch(system_time) - timestamp_delta};
+  return std::chrono::steady_clock::time_point{
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+          time_since_epoch)};
+}
+} // namespace lightstep

--- a/src/common/timestamp.h
+++ b/src/common/timestamp.h
@@ -4,13 +4,28 @@
 #include <cstdint>
 
 namespace lightstep {
+/**
+ * Computes a delta between the steady and system clocks that can be used for
+ * timestamp conversions.
+ * @return the timestamp delta
+ */
 int64_t ComputeSystemSteadyTimestampDelta() noexcept;
 
+/**
+ * Convert a steady time point to a system time point
+ * @param timestamp_delta the system-steady timestamp delta
+ * @param steady_timestamp the steady timestamp
+ */
 std::chrono::system_clock::time_point ToSystemTimestamp(
     int64_t timestamp_delta,
-    std::chrono::steady_clock::time_point steady_time) noexcept;
+    std::chrono::steady_clock::time_point steady_timestamp) noexcept;
 
+/**
+ * Convert a system time point to a steady time point
+ * @param timestamp_delta the system-steady timestamp delta
+ * @param system_timestamp the system timestamp
+ */
 std::chrono::steady_clock::time_point ToSteadyTimestamp(
     int64_t timestamp_delta,
-    std::chrono::system_clock::time_point system_time) noexcept;
+    std::chrono::system_clock::time_point system_timestamp) noexcept;
 }  // namespace lightstep

--- a/src/common/timestamp.h
+++ b/src/common/timestamp.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+namespace lightstep {
+int64_t ComputeSystemSteadyTimestampDelta() noexcept;
+
+std::chrono::system_clock::time_point ToSystemTimestamp(
+    int64_t timestamp_delta,
+    std::chrono::steady_clock::time_point steady_time) noexcept;
+
+std::chrono::steady_clock::time_point ToSteadyTimestamp(
+    int64_t timestamp_delta,
+    std::chrono::system_clock::time_point system_time) noexcept;
+}  // namespace lightstep

--- a/src/recorder/BUILD
+++ b/src/recorder/BUILD
@@ -36,6 +36,7 @@ lightstep_cc_library(
     ],
     deps = [
         "//src/common:serialization_chain_lib",
+        "//src/common:timestamp_lib",
         "//lightstep-tracer-common:collector_proto_cc",
         "//include/lightstep:tracer_interface",
     ],

--- a/src/recorder/recorder.h
+++ b/src/recorder/recorder.h
@@ -44,5 +44,13 @@ class Recorder {
       std::chrono::system_clock::duration /*timeout*/) noexcept {
     return true;
   }
+
+  /* virtual std::chrono::duration::nanoseconds system_steady_timestamp_delta() noexcept { */
+  /* } */
+
+  virtual std::chrono::system_clock::time_point ComputeCurrentSystemTime(
+      std::chrono::steady_clock::time_point /*steady_now*/) noexcept {
+    return std::chrono::system_clock::now();
+  }
 };
 }  // namespace lightstep

--- a/src/recorder/recorder.h
+++ b/src/recorder/recorder.h
@@ -46,10 +46,27 @@ class Recorder {
     return true;
   }
 
+  /**
+   * Compute a timestamp delta that con be used to convert between system and
+   * steady timestamps.
+   *
+   * Having the the recorder provide this functionality
+   * allows it to cache and regulary refresh the value to avoid the performance
+   * cost of always computing it.
+   * @return the timestamp delta
+   */
   virtual int64_t ComputeSystemSteadyTimestampDelta() const noexcept {
     return ComputeSystemSteadyTimestampDelta();
   }
 
+  /**
+   * Compute the current system time from current steady time point.
+   *
+   * If the recorder caches a timestamp delta, it can avoid a call to
+   * system_clock::now.
+   * @param steady_now the current steady timestamp
+   * @return the current system timestamp
+   */
   virtual std::chrono::system_clock::time_point ComputeCurrentSystemTimestamp(
       std::chrono::steady_clock::time_point /*steady_now*/) const noexcept {
     return std::chrono::system_clock::now();

--- a/src/recorder/recorder.h
+++ b/src/recorder/recorder.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "common/serialization_chain.h"
+#include "common/timestamp.h"
 
 #include <lightstep/tracer.h>
 #include "lightstep-tracer-common/collector.pb.h"
@@ -45,11 +46,12 @@ class Recorder {
     return true;
   }
 
-  /* virtual std::chrono::duration::nanoseconds system_steady_timestamp_delta() noexcept { */
-  /* } */
+  virtual int64_t ComputeSystemSteadyTimestampDelta() const noexcept {
+    return ComputeSystemSteadyTimestampDelta();
+  }
 
-  virtual std::chrono::system_clock::time_point ComputeCurrentSystemTime(
-      std::chrono::steady_clock::time_point /*steady_now*/) noexcept {
+  virtual std::chrono::system_clock::time_point ComputeCurrentSystemTimestamp(
+      std::chrono::steady_clock::time_point /*steady_now*/) const noexcept {
     return std::chrono::system_clock::now();
   }
 };

--- a/src/recorder/recorder.h
+++ b/src/recorder/recorder.h
@@ -56,7 +56,7 @@ class Recorder {
    * @return the timestamp delta
    */
   virtual int64_t ComputeSystemSteadyTimestampDelta() const noexcept {
-    return ComputeSystemSteadyTimestampDelta();
+    return lightstep::ComputeSystemSteadyTimestampDelta();
   }
 
   /**

--- a/src/recorder/stream_recorder/stream_recorder.h
+++ b/src/recorder/stream_recorder/stream_recorder.h
@@ -85,6 +85,17 @@ class StreamRecorder final : public ForkAwareRecorder, private Noncopyable {
   bool FlushWithTimeout(
       std::chrono::system_clock::duration timeout) noexcept override;
 
+  int64_t ComputeSystemSteadyTimestampDelta() const noexcept override {
+    return stream_recorder_impl_->timestamp_delta();
+  }
+
+  std::chrono::system_clock::time_point ComputeCurrentSystemTimestamp(
+      std::chrono::steady_clock::time_point steady_now) const
+      noexcept override {
+    return ToSystemTimestamp(stream_recorder_impl_->timestamp_delta(),
+                             steady_now);
+  }
+
   // ForkAwareRecorder
   void PrepareForFork() noexcept override;
 

--- a/src/recorder/stream_recorder/stream_recorder2.h
+++ b/src/recorder/stream_recorder/stream_recorder2.h
@@ -83,6 +83,17 @@ class StreamRecorder2 : public ForkAwareRecorder, private Noncopyable {
   bool FlushWithTimeout(
       std::chrono::system_clock::duration timeout) noexcept override;
 
+  int64_t ComputeSystemSteadyTimestampDelta() const noexcept override {
+    return stream_recorder_impl_->timestamp_delta();
+  }
+
+  std::chrono::system_clock::time_point ComputeCurrentSystemTimestamp(
+      std::chrono::steady_clock::time_point steady_now) const
+      noexcept override {
+    return ToSystemTimestamp(stream_recorder_impl_->timestamp_delta(),
+                             steady_now);
+  }
+
   // ForkAwareRecorder
   void PrepareForFork() noexcept override;
 

--- a/src/recorder/stream_recorder/stream_recorder_impl.cpp
+++ b/src/recorder/stream_recorder/stream_recorder_impl.cpp
@@ -19,7 +19,7 @@ StreamRecorderImpl::StreamRecorderImpl(StreamRecorder& stream_recorder)
           event_base_,
           stream_recorder_.recorder_options().timestamp_delta_period,
           MakeTimerCallback<StreamRecorderImpl,
-                            &StreamRecorderImpl::ComputeTimestampDelta>(),
+                            &StreamRecorderImpl::RefreshTimestampDelta>(),
           static_cast<void*>(this)},
       flush_timer_{
           event_base_, stream_recorder_.recorder_options().flushing_period,
@@ -82,9 +82,9 @@ void StreamRecorderImpl::Poll() noexcept {
 }
 
 //--------------------------------------------------------------------------------------------------
-// ComputeTimestampDelta
+// RefreshTimestampDelta
 //--------------------------------------------------------------------------------------------------
-void StreamRecorderImpl::ComputeTimestampDelta() noexcept {
+void StreamRecorderImpl::RefreshTimestampDelta() noexcept {
   timestamp_delta_ = ComputeSystemSteadyTimestampDelta();
 }
 

--- a/src/recorder/stream_recorder/stream_recorder_impl.cpp
+++ b/src/recorder/stream_recorder/stream_recorder_impl.cpp
@@ -15,6 +15,12 @@ StreamRecorderImpl::StreamRecorderImpl(StreamRecorder& stream_recorder)
           event_base_, stream_recorder_.recorder_options().polling_period,
           MakeTimerCallback<StreamRecorderImpl, &StreamRecorderImpl::Poll>(),
           static_cast<void*>(this)},
+      timestamp_delta_timer_{
+          event_base_,
+          stream_recorder_.recorder_options().timestamp_delta_period,
+          MakeTimerCallback<StreamRecorderImpl,
+                            &StreamRecorderImpl::ComputeTimestampDelta>(),
+          static_cast<void*>(this)},
       flush_timer_{
           event_base_, stream_recorder_.recorder_options().flushing_period,
           MakeTimerCallback<StreamRecorderImpl, &StreamRecorderImpl::Flush>(),

--- a/src/recorder/stream_recorder/stream_recorder_impl.cpp
+++ b/src/recorder/stream_recorder/stream_recorder_impl.cpp
@@ -76,6 +76,13 @@ void StreamRecorderImpl::Poll() noexcept {
 }
 
 //--------------------------------------------------------------------------------------------------
+// ComputeTimestampDelta
+//--------------------------------------------------------------------------------------------------
+void StreamRecorderImpl::ComputeTimestampDelta() noexcept {
+  timestamp_delta_ = ComputeSystemSteadyTimestampDelta();
+}
+
+//--------------------------------------------------------------------------------------------------
 // Flush
 //--------------------------------------------------------------------------------------------------
 void StreamRecorderImpl::Flush() noexcept try {

--- a/src/recorder/stream_recorder/stream_recorder_impl.h
+++ b/src/recorder/stream_recorder/stream_recorder_impl.h
@@ -4,6 +4,7 @@
 #include <thread>
 
 #include "common/noncopyable.h"
+#include "common/timestamp.h"
 #include "network/event_base.h"
 #include "network/timer_event.h"
 #include "recorder/stream_recorder/satellite_streamer.h"
@@ -24,22 +25,28 @@ class StreamRecorderImpl : private Noncopyable {
 
   ~StreamRecorderImpl() noexcept;
 
+  int64_t timestamp_delta() const noexcept { return timestamp_delta_; }
+
  private:
   StreamRecorder& stream_recorder_;
 
   EventBase event_base_;
   size_t early_flush_marker_;
   TimerEvent poll_timer_;
+  TimerEvent timestamp_delta_timer_;
   TimerEvent flush_timer_;
 
   SatelliteStreamer streamer_;
 
   std::thread thread_;
   std::atomic<bool> exit_{false};
+  std::atomic<int64_t> timestamp_delta_{ComputeSystemSteadyTimestampDelta()};
 
   void Run() noexcept;
 
   void Poll() noexcept;
+
+  void ComputeTimestampDelta() noexcept;
 
   void Flush() noexcept;
 };

--- a/src/recorder/stream_recorder/stream_recorder_impl.h
+++ b/src/recorder/stream_recorder/stream_recorder_impl.h
@@ -46,7 +46,7 @@ class StreamRecorderImpl : private Noncopyable {
 
   void Poll() noexcept;
 
-  void ComputeTimestampDelta() noexcept;
+  void RefreshTimestampDelta() noexcept;
 
   void Flush() noexcept;
 };

--- a/src/recorder/stream_recorder/stream_recorder_impl2.cpp
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.cpp
@@ -15,6 +15,12 @@ StreamRecorderImpl2::StreamRecorderImpl2(StreamRecorder2& stream_recorder)
           event_base_, stream_recorder_.recorder_options().polling_period,
           MakeTimerCallback<StreamRecorderImpl2, &StreamRecorderImpl2::Poll>(),
           static_cast<void*>(this)},
+      timestamp_delta_timer_{
+          event_base_,
+          stream_recorder_.recorder_options().timestamp_delta_period,
+          MakeTimerCallback<StreamRecorderImpl2,
+                            &StreamRecorderImpl2::ComputeTimestampDelta>(),
+          static_cast<void*>(this)},
       flush_timer_{
           event_base_, stream_recorder_.recorder_options().flushing_period,
           MakeTimerCallback<StreamRecorderImpl2, &StreamRecorderImpl2::Flush>(),
@@ -73,6 +79,13 @@ void StreamRecorderImpl2::Poll() noexcept {
   }
 
   stream_recorder_.Poll();
+}
+
+//--------------------------------------------------------------------------------------------------
+// ComputeTimestampDelta
+//--------------------------------------------------------------------------------------------------
+void StreamRecorderImpl2::ComputeTimestampDelta() noexcept {
+  timestamp_delta_ = ComputeSystemSteadyTimestampDelta();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/recorder/stream_recorder/stream_recorder_impl2.cpp
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.cpp
@@ -19,7 +19,7 @@ StreamRecorderImpl2::StreamRecorderImpl2(StreamRecorder2& stream_recorder)
           event_base_,
           stream_recorder_.recorder_options().timestamp_delta_period,
           MakeTimerCallback<StreamRecorderImpl2,
-                            &StreamRecorderImpl2::ComputeTimestampDelta>(),
+                            &StreamRecorderImpl2::RefreshTimestampDelta>(),
           static_cast<void*>(this)},
       flush_timer_{
           event_base_, stream_recorder_.recorder_options().flushing_period,
@@ -82,9 +82,9 @@ void StreamRecorderImpl2::Poll() noexcept {
 }
 
 //--------------------------------------------------------------------------------------------------
-// ComputeTimestampDelta
+// RefreshTimestampDelta
 //--------------------------------------------------------------------------------------------------
-void StreamRecorderImpl2::ComputeTimestampDelta() noexcept {
+void StreamRecorderImpl2::RefreshTimestampDelta() noexcept {
   timestamp_delta_ = ComputeSystemSteadyTimestampDelta();
 }
 

--- a/src/recorder/stream_recorder/stream_recorder_impl2.h
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.h
@@ -25,6 +25,9 @@ class StreamRecorderImpl2 : private Noncopyable {
 
   ~StreamRecorderImpl2() noexcept;
 
+  /**
+   * @return the last system-steady timestamp delta.
+   */
   int64_t timestamp_delta() const noexcept { return timestamp_delta_; }
 
  private:

--- a/src/recorder/stream_recorder/stream_recorder_impl2.h
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.h
@@ -49,7 +49,7 @@ class StreamRecorderImpl2 : private Noncopyable {
 
   void Poll() noexcept;
 
-  void ComputeTimestampDelta() noexcept;
+  void RefreshTimestampDelta() noexcept;
 
   void Flush() noexcept;
 };

--- a/src/recorder/stream_recorder/stream_recorder_impl2.h
+++ b/src/recorder/stream_recorder/stream_recorder_impl2.h
@@ -4,6 +4,7 @@
 #include <thread>
 
 #include "common/noncopyable.h"
+#include "common/timestamp.h"
 #include "network/event_base.h"
 #include "network/timer_event.h"
 #include "recorder/stream_recorder/satellite_streamer2.h"
@@ -24,22 +25,28 @@ class StreamRecorderImpl2 : private Noncopyable {
 
   ~StreamRecorderImpl2() noexcept;
 
+  int64_t timestamp_delta() const noexcept { return timestamp_delta_; }
+
  private:
   StreamRecorder2& stream_recorder_;
 
   EventBase event_base_;
   size_t early_flush_marker_;
   TimerEvent poll_timer_;
+  TimerEvent timestamp_delta_timer_;
   TimerEvent flush_timer_;
 
   SatelliteStreamer2 streamer_;
 
   std::thread thread_;
   std::atomic<bool> exit_{false};
+  std::atomic<int64_t> timestamp_delta_{ComputeSystemSteadyTimestampDelta()};
 
   void Run() noexcept;
 
   void Poll() noexcept;
+
+  void ComputeTimestampDelta() noexcept;
 
   void Flush() noexcept;
 };

--- a/src/recorder/stream_recorder/stream_recorder_options.h
+++ b/src/recorder/stream_recorder/stream_recorder_options.h
@@ -30,6 +30,10 @@ struct StreamRecorderOptions {
       std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::milliseconds{1});
 
+  std::chrono::microseconds timestamp_delta_period =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::milliseconds{500});
+
   // The amount of time between flushes of StreamRecorder's span buffer.
   std::chrono::microseconds flushing_period =
       std::chrono::duration_cast<std::chrono::microseconds>(

--- a/src/tracer/BUILD
+++ b/src/tracer/BUILD
@@ -39,6 +39,9 @@ lightstep_cc_library(
     srcs = [
         "utility.cpp",
     ],
+    deps = [
+        "//src/recorder:recorder_interface",
+    ],
     external_deps = [
         "@io_opentracing_cpp//:opentracing",
     ],

--- a/src/tracer/legacy/legacy_span.cpp
+++ b/src/tracer/legacy/legacy_span.cpp
@@ -68,8 +68,9 @@ LegacySpan::LegacySpan(std::shared_ptr<const opentracing::Tracer>&& tracer,
 
   // Set the start timestamps.
   std::chrono::system_clock::time_point start_timestamp;
-  std::tie(start_timestamp, start_steady_) = ComputeStartTimestamps(
-      options.start_system_timestamp, options.start_steady_timestamp);
+  std::tie(start_timestamp, start_steady_) =
+      ComputeStartTimestamps(recorder_, options.start_system_timestamp,
+                             options.start_steady_timestamp);
   *span_.mutable_start_timestamp() = ToTimestamp(start_timestamp);
 
   // Set any span references.

--- a/src/tracer/span.cpp
+++ b/src/tracer/span.cpp
@@ -27,7 +27,8 @@ Span::Span(std::shared_ptr<const TracerImpl>&& tracer,
   // Set the start timestamps.
   std::chrono::system_clock::time_point start_timestamp;
   std::tie(start_timestamp, start_steady_) = ComputeStartTimestamps(
-      options.start_system_timestamp, options.start_steady_timestamp);
+      tracer_->recorder(), options.start_system_timestamp,
+      options.start_steady_timestamp);
   WriteStartTimestamp(stream_, start_timestamp);
 
   // Set any span references.

--- a/src/tracer/utility.cpp
+++ b/src/tracer/utility.cpp
@@ -23,6 +23,8 @@ std::tuple<SystemTime, SteadyTime> ComputeStartTimestamps(
       start_steady_timestamp == SteadyTime()) {
     return std::tuple<SystemTime, SteadyTime>{SystemClock::now(),
                                               SteadyClock::now()};
+    /* return std::tuple<SystemTime, SteadyTime>{SystemTime{}, */
+    /*                                           SteadyClock::now()}; */
   }
   if (start_system_timestamp == SystemTime()) {
     return std::tuple<SystemTime, SteadyTime>{

--- a/src/tracer/utility.cpp
+++ b/src/tracer/utility.cpp
@@ -14,27 +14,28 @@ bool is_sampled(const opentracing::Value& value) noexcept {
 // ComputeStartTimestamps
 //------------------------------------------------------------------------------
 std::tuple<SystemTime, SteadyTime> ComputeStartTimestamps(
-    const SystemTime& start_system_timestamp,
+    const Recorder& recorder, const SystemTime& start_system_timestamp,
     const SteadyTime& start_steady_timestamp) noexcept {
   // If neither the system nor steady timestamps are set, get the tme from the
   // respective clocks; otherwise, use the set timestamp to initialize the
   // other.
   if (start_system_timestamp == SystemTime() &&
       start_steady_timestamp == SteadyTime()) {
-    return std::tuple<SystemTime, SteadyTime>{SystemClock::now(),
-                                              SteadyClock::now()};
-    /* return std::tuple<SystemTime, SteadyTime>{SystemTime{}, */
-    /*                                           SteadyClock::now()}; */
+    auto steady_now = SteadyClock::now();
+    return std::tuple<SystemTime, SteadyTime>{
+        recorder.ComputeCurrentSystemTimestamp(steady_now), steady_now};
   }
   if (start_system_timestamp == SystemTime()) {
+    auto timestamp_delta = recorder.ComputeSystemSteadyTimestampDelta();
     return std::tuple<SystemTime, SteadyTime>{
-        opentracing::convert_time_point<SystemClock>(start_steady_timestamp),
+        ToSystemTimestamp(timestamp_delta, start_steady_timestamp),
         start_steady_timestamp};
   }
   if (start_steady_timestamp == SteadyTime()) {
+    auto timestamp_delta = recorder.ComputeSystemSteadyTimestampDelta();
     return std::tuple<SystemTime, SteadyTime>{
         start_system_timestamp,
-        opentracing::convert_time_point<SteadyClock>(start_system_timestamp)};
+        ToSteadyTimestamp(timestamp_delta, start_system_timestamp)};
   }
   return std::tuple<SystemTime, SteadyTime>{start_system_timestamp,
                                             start_steady_timestamp};

--- a/src/tracer/utility.h
+++ b/src/tracer/utility.h
@@ -3,6 +3,8 @@
 #include <chrono>
 #include <tuple>
 
+#include "recorder/recorder.h"
+
 #include <opentracing/value.h>
 
 namespace lightstep {
@@ -14,6 +16,6 @@ using SteadyTime = SteadyClock::time_point;
 bool is_sampled(const opentracing::Value& value) noexcept;
 
 std::tuple<SystemTime, SteadyTime> ComputeStartTimestamps(
-    const SystemTime& start_system_timestamp,
+    const Recorder& recorder, const SystemTime& start_system_timestamp,
     const SteadyTime& start_steady_timestamp) noexcept;
 }  // namespace lightstep

--- a/src/tracer/utility.h
+++ b/src/tracer/utility.h
@@ -13,8 +13,19 @@ using SteadyClock = std::chrono::steady_clock;
 using SystemTime = SystemClock::time_point;
 using SteadyTime = SteadyClock::time_point;
 
+/**
+ * @return true if value indicates we should sample.
+ */
 bool is_sampled(const opentracing::Value& value) noexcept;
 
+/**
+ * Compute the start timestamps of a span.
+ * @param recorder the recorder
+ * @param start_system_timestamp the system start time or SystemTime{} if not
+ * set
+ * @param start_steady_timestamp the steady start time  or SteadyTime{} if not
+ * set
+ */
 std::tuple<SystemTime, SteadyTime> ComputeStartTimestamps(
     const Recorder& recorder, const SystemTime& start_system_timestamp,
     const SteadyTime& start_steady_timestamp) noexcept;

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -221,3 +221,13 @@ lightstep_catch_test(
         ":test_proto_cc",
     ],
 )
+
+lightstep_catch_test(
+    name = "timestamp_test",
+    srcs = [
+        "timestamp_test.cpp",
+    ],
+    deps = [
+        "//src/common:timestamp_lib",
+    ],
+)

--- a/test/common/timestamp_test.cpp
+++ b/test/common/timestamp_test.cpp
@@ -1,0 +1,25 @@
+#include "common/timestamp.h"
+
+#include <cmath>
+
+#include "3rd_party/catch2/catch.hpp"
+using namespace lightstep;
+
+TEST_CASE(
+    "A system-steady timestamp delta can be used to convert between the "
+    "different timestamps") {
+  auto timestamp_delta = ComputeSystemSteadyTimestampDelta();
+  auto system_now = std::chrono::system_clock::now();
+  auto steady_now = std::chrono::steady_clock::now();
+
+  auto system_now_prime = ToSystemTimestamp(timestamp_delta, steady_now);
+  auto steady_now_prime = ToSteadyTimestamp(timestamp_delta, system_now);
+
+  REQUIRE(std::abs(std::chrono::duration_cast<std::chrono::microseconds>(
+                       system_now_prime - system_now)
+                       .count()) < 100);
+
+  REQUIRE(std::abs(std::chrono::duration_cast<std::chrono::microseconds>(
+                       steady_now_prime - steady_now)
+                       .count()) < 100);
+}


### PR DESCRIPTION
Avoids the cost of timestamping twice when starting a span by caching the system-steady delta in the recorder.

These are the benchmark times I got running on my machine before the change:
```
-----------------------------------------------------------------------------
Benchmark                                      Time           CPU Iterations
-----------------------------------------------------------------------------
BM_SpanCreation/rpc                        18012 ns      17830 ns      33544
BM_SpanCreation/stream                     18525 ns      18497 ns      36456
BM_SpanCreation/stream2                    18736 ns      18706 ns      37213
```
and after the change:
```
-----------------------------------------------------------------------------
Benchmark                                      Time           CPU Iterations
-----------------------------------------------------------------------------
BM_SpanCreation/rpc                        18401 ns      18077 ns      35548
BM_SpanCreation/stream                     13388 ns      13345 ns      49015
BM_SpanCreation/stream2                    14892 ns      14837 ns      34336
```
(this change only affects the stream times)