### PR TITLE
Replace snprintf in SerializationChain 

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -32,3 +32,10 @@ cc_library(
         "-Wl,--allow-multiple-definition", 
     ],
 )
+
+sh_binary(
+    name = "profile_benchmark",
+    srcs = [
+        "profile_benchmark.sh",
+    ],
+)

--- a/bazel/lightstep_build_system.bzl
+++ b/bazel/lightstep_build_system.bzl
@@ -224,7 +224,19 @@ def lightstep_google_benchmark(
       tools = [":" + name] + data,
       testonly = 1,
       cmd = "$(location :%s) --benchmark_color=false --benchmark_min_time=.01 &> $@" % name,
-)
+  )
+  native.genrule(
+      name = name + "_profile",
+      outs = [
+          name + "_profile.tgz",
+      ],
+      tools = [
+          ":" + name,
+          "//bazel:profile_benchmark",
+      ] + data,
+      testonly = 1,
+      cmd = "$(location //bazel:profile_benchmark) $$PWD/$(location :%s) $@" % name,
+  )
 
 def lightstep_go_binary(
     name,

--- a/bazel/profile_benchmark.sh
+++ b/bazel/profile_benchmark.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+BENCHMARK=$1
+OUTPUT=$2
+BENCHMARK_NAME=$(basename $BENCHMARK)
+BENCHMARKS=$($BENCHMARK --benchmark_list_tests)
+TEMPDIR=$(mktemp -d)
+echo $TEMPDIR
+pushd $TEMPDIR
+for FILTER in $BENCHMARKS; do
+  valgrind --tool=callgrind $BENCHMARK --benchmark_filter=$FILTER$
+  gprof2dot --format=callgrind --output=out.dot callgrind.out.*
+  FILTER_PRIME=$(echo $FILTER | tr / -)
+  dot -Tpng out.dot -o "$BENCHMARK_NAME-$FILTER_PRIME.png"
+  rm callgrind.out.*
+  rm *.dot
+  tar zcf $(basename $OUTPUT) *.png
+done
+popd
+mv $TEMPDIR/$(basename $OUTPUT) $OUTPUT

--- a/ci/setup_build_environment.sh
+++ b/ci/setup_build_environment.sh
@@ -24,4 +24,8 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 libffi-dev \
                 python3 \
                 zip \
-                gettext-base
+                gettext-base \
+                valgrind \
+                graphviz
+pip install wheel
+pip install gprof2dot

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -29,6 +29,9 @@ class Logger {
 
   template <class... Tx>
   void Log(LogLevel level, const Tx&... tx) noexcept try {
+    if (static_cast<int>(level) < static_cast<int>(level_)) {
+      return;
+    }
     std::ostringstream oss;
     Concatenate(oss, tx...);
     Log(level, opentracing::string_view{oss.str()});

--- a/src/common/serialization_chain.cpp
+++ b/src/common/serialization_chain.cpp
@@ -20,7 +20,7 @@ static int WriteChunkHeader(char* data, size_t data_length,
   auto chunk_size_str =
       Uint32ToHex(static_cast<uint32_t>(chunk_size), buffer.data());
   assert(chunk_size_str.size() + 2 <= data_length);
-  assert(chunk_size_str.size() > 0);
+  assert(!chunk_size_str.empty());
   auto first = std::find_if(chunk_size_str.begin(), chunk_size_str.end() - 1,
                             [](char c) { return c != '0'; });
   auto iter = std::copy(first, chunk_size_str.end(), data);

--- a/src/common/serialization_chain.cpp
+++ b/src/common/serialization_chain.cpp
@@ -1,9 +1,33 @@
 #include "common/serialization_chain.h"
 
+#include <algorithm>
+#include <cassert>
+
+#include "common/utility.h"
+
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 
 namespace lightstep {
 static const char* LineTerminator = "\r\n";
+
+//--------------------------------------------------------------------------------------------------
+// WriteChunkHeader
+//--------------------------------------------------------------------------------------------------
+static int WriteChunkHeader(char* data, size_t data_length,
+                            size_t chunk_size) noexcept {
+  (void)data_length;
+  std::array<char, Num32BitHexDigits> buffer;
+  auto chunk_size_str =
+      Uint32ToHex(static_cast<uint32_t>(chunk_size), buffer.data());
+  assert(chunk_size_str.size() + 2 <= data_length);
+  assert(chunk_size_str.size() > 0);
+  auto first = std::find_if(chunk_size_str.begin(), chunk_size_str.end() - 1,
+                            [](char c) { return c != '0'; });
+  auto iter = std::copy(first, chunk_size_str.end(), data);
+  *iter++ = '\r';
+  *iter++ = '\n';
+  return static_cast<int>(std::distance(data, iter));
+}
 
 //--------------------------------------------------------------------------------------------------
 // constructor
@@ -17,10 +41,10 @@ void SerializationChain::AddFraming() noexcept {
   auto protobuf_header_size =
       ComputeLengthDelimitedHeaderSerializationSize<ReportRequestSpansField>(
           num_bytes_written_);
-  header_size_ = std::snprintf(
-      header_.data(), header_.size(), "%llX\r\n",
-      static_cast<unsigned long long>(static_cast<size_t>(num_bytes_written_) +
-                                      protobuf_header_size));
+  (void)WriteChunkHeader;
+  header_size_ = WriteChunkHeader(
+      header_.data(), header_.size(),
+      static_cast<size_t>(num_bytes_written_) + protobuf_header_size);
   assert(header_size_ > 0);
 
   // Serialize the spans key field and length

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -26,7 +26,6 @@ std::tuple<uint64_t, uint32_t> ProtobufFormatTimestamp(
   auto nanos =
       std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch())
           .count();
-  google::protobuf::Timestamp ts;
   const uint64_t nanosPerSec = 1000000000;
   return {static_cast<uint64_t>(nanos / nanosPerSec),
           static_cast<uint32_t>(nanos % nanosPerSec)};

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -18,6 +18,24 @@
 #include <pthread.h>
 
 namespace lightstep {
+static const unsigned char HexDigitLookupTable[513] =
+    "000102030405060708090A0B0C0D0E0F"
+    "101112131415161718191A1B1C1D1E1F"
+    "202122232425262728292A2B2C2D2E2F"
+    "303132333435363738393A3B3C3D3E3F"
+    "404142434445464748494A4B4C4D4E4F"
+    "505152535455565758595A5B5C5D5E5F"
+    "606162636465666768696A6B6C6D6E6F"
+    "707172737475767778797A7B7C7D7E7F"
+    "808182838485868788898A8B8C8D8E8F"
+    "909192939495969798999A9B9C9D9E9F"
+    "A0A1A2A3A4A5A6A7A8A9AAABACADAEAF"
+    "B0B1B2B3B4B5B6B7B8B9BABBBCBDBEBF"
+    "C0C1C2C3C4C5C6C7C8C9CACBCCCDCECF"
+    "D0D1D2D3D4D5D6D7D8D9DADBDCDDDEDF"
+    "E0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF"
+    "F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF";
+
 //------------------------------------------------------------------------------
 // ProtobufFormatTimestamp
 //------------------------------------------------------------------------------
@@ -266,30 +284,28 @@ void LogReportResponse(Logger& logger, bool verbose,
 // This uses the lookup table solution described on this blog post
 // https://johnnylee-sde.github.io/Fast-unsigned-integer-to-hex-string/
 opentracing::string_view Uint64ToHex(uint64_t x, char* output) {
-  static const unsigned char digits[513] =
-      "000102030405060708090A0B0C0D0E0F"
-      "101112131415161718191A1B1C1D1E1F"
-      "202122232425262728292A2B2C2D2E2F"
-      "303132333435363738393A3B3C3D3E3F"
-      "404142434445464748494A4B4C4D4E4F"
-      "505152535455565758595A5B5C5D5E5F"
-      "606162636465666768696A6B6C6D6E6F"
-      "707172737475767778797A7B7C7D7E7F"
-      "808182838485868788898A8B8C8D8E8F"
-      "909192939495969798999A9B9C9D9E9F"
-      "A0A1A2A3A4A5A6A7A8A9AAABACADAEAF"
-      "B0B1B2B3B4B5B6B7B8B9BABBBCBDBEBF"
-      "C0C1C2C3C4C5C6C7C8C9CACBCCCDCECF"
-      "D0D1D2D3D4D5D6D7D8D9DADBDCDDDEDF"
-      "E0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF"
-      "F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF";
   for (int i = 8; i-- > 0;) {
     auto lookup_index = (x & 0xFF) * 2;
-    output[i * 2] = digits[lookup_index];
-    output[i * 2 + 1] = digits[lookup_index + 1];
+    output[i * 2] = HexDigitLookupTable[lookup_index];
+    output[i * 2 + 1] = HexDigitLookupTable[lookup_index + 1];
     x >>= 8;
   }
   return {output, Num64BitHexDigits};
+}
+
+//------------------------------------------------------------------------------
+// Uint32ToHex
+//------------------------------------------------------------------------------
+// This uses the lookup table solution described on this blog post
+// https://johnnylee-sde.github.io/Fast-unsigned-integer-to-hex-string/
+opentracing::string_view Uint32ToHex(uint32_t x, char* output) {
+  for (int i = 4; i-- > 0;) {
+    auto lookup_index = (x & 0xFF) * 2;
+    output[i * 2] = HexDigitLookupTable[lookup_index];
+    output[i * 2 + 1] = HexDigitLookupTable[lookup_index + 1];
+    x >>= 8;
+  }
+  return {output, Num32BitHexDigits};
 }
 
 //------------------------------------------------------------------------------

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -84,14 +84,16 @@ void LogReportResponse(Logger& logger, bool verbose,
 /**
  * Writes a 64-bit number in hex.
  * @param x the number to write
- * @output where to output the nbumber
+ * @param output where to output the nbumber
+ * @return x as a hex string
  */
 opentracing::string_view Uint64ToHex(uint64_t x, char* output);
 
 /**
  * Writes a 32-bit number in hex.
  * @param x the number to write
- * @output where to output the nbumber
+ * @param output where to output the nbumber
+ * @return x as a hex string
  */
 opentracing::string_view Uint32ToHex(uint32_t x, char* output);
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -84,7 +84,7 @@ void LogReportResponse(Logger& logger, bool verbose,
 /**
  * Writes a 64-bit number in hex.
  * @param x the number to write
- * @param output where to output the nbumber
+ * @param output where to output the number
  * @return x as a hex string
  */
 opentracing::string_view Uint64ToHex(uint64_t x, char* output);
@@ -92,7 +92,7 @@ opentracing::string_view Uint64ToHex(uint64_t x, char* output);
 /**
  * Writes a 32-bit number in hex.
  * @param x the number to write
- * @param output where to output the nbumber
+ * @param output where to output the number
  * @return x as a hex string
  */
 opentracing::string_view Uint32ToHex(uint32_t x, char* output);

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -15,6 +15,7 @@
 
 namespace lightstep {
 const size_t Num64BitHexDigits = std::numeric_limits<uint64_t>::digits / 4;
+const size_t Num32BitHexDigits = std::numeric_limits<uint32_t>::digits / 4;
 
 /**
  * Breaks the timestamp down into seconds past epoch and nanosecond fraction
@@ -80,9 +81,19 @@ collector::Log ToLog(std::chrono::system_clock::time_point timestamp,
 void LogReportResponse(Logger& logger, bool verbose,
                        const collector::ReportResponse& response);
 
-// Converts `x` to a hexidecimal, writes the results into `output` and returns
-// a string_view of the number.
+/**
+ * Writes a 64-bit number in hex.
+ * @param x the number to write
+ * @output where to output the nbumber
+ */
 opentracing::string_view Uint64ToHex(uint64_t x, char* output);
+
+/**
+ * Writes a 32-bit number in hex.
+ * @param x the number to write
+ * @output where to output the nbumber
+ */
+opentracing::string_view Uint32ToHex(uint32_t x, char* output);
 
 // Converts a hexidecimal number to a 64-bit integer. Either returns the number
 // or an error code.

--- a/test/common/utility_test.cpp
+++ b/test/common/utility_test.cpp
@@ -11,49 +11,49 @@ using namespace opentracing;
 TEST_CASE("Json") {
   SECTION("Arrays jsonify correctly.") {
     auto key_value1 = ToKeyValue("", Values{1});
-    CHECK(key_value1.json_value() == "[1]");
+    REQUIRE(key_value1.json_value() == "[1]");
     auto key_value2 = ToKeyValue("", Values{1, 2});
-    CHECK(key_value2.json_value() == "[1,2]");
+    REQUIRE(key_value2.json_value() == "[1,2]");
   }
 
   SECTION("Dictionaries jsonify correctly.") {
     auto key_value1 = ToKeyValue("", Dictionary{{"abc", 123}});
-    CHECK(key_value1.json_value() == R"({"abc":123})");
+    REQUIRE(key_value1.json_value() == R"({"abc":123})");
   }
 
   SECTION("Compound aggregates jsonify correctly.") {
     auto key_value1 = ToKeyValue("", Dictionary{{"abc", Values{1, 2}}});
-    CHECK(key_value1.json_value() == R"({"abc":[1,2]})");
+    REQUIRE(key_value1.json_value() == R"({"abc":[1,2]})");
   }
 
   SECTION("Special characters in strings are escaped.") {
     auto key_value1 = ToKeyValue("", Values{"\"\n\t\x0f"});
-    CHECK(key_value1.json_value() == R"(["\"\n\t\u000f"])");
+    REQUIRE(key_value1.json_value() == R"(["\"\n\t\u000f"])");
   }
 
   SECTION("Doubles jsonify correctly.") {
     auto key_value1 = ToKeyValue("", Values{1.5});
-    CHECK(key_value1.json_value() == R"([1.5])");
+    REQUIRE(key_value1.json_value() == R"([1.5])");
     auto key_value2 = ToKeyValue("", Values{std::nan(" ")});
-    CHECK(key_value2.json_value() == R"(["NaN"])");
+    REQUIRE(key_value2.json_value() == R"(["NaN"])");
     auto key_value3 =
         ToKeyValue("", Values{std::numeric_limits<double>::infinity()});
-    CHECK(key_value3.json_value() == R"(["+Inf"])");
+    REQUIRE(key_value3.json_value() == R"(["+Inf"])");
     auto key_value4 =
         ToKeyValue("", Values{-std::numeric_limits<double>::infinity()});
-    CHECK(key_value4.json_value() == R"(["-Inf"])");
+    REQUIRE(key_value4.json_value() == R"(["-Inf"])");
   }
 
   SECTION("Bools jsonify correctly.") {
     auto key_value1 = ToKeyValue("", Values{true});
-    CHECK(key_value1.json_value() == "[true]");
+    REQUIRE(key_value1.json_value() == "[true]");
     auto key_value2 = ToKeyValue("", Values{false});
-    CHECK(key_value2.json_value() == "[false]");
+    REQUIRE(key_value2.json_value() == "[false]");
   }
 
   SECTION("nullptr jsonifies to null.") {
     auto key_value1 = ToKeyValue("", Values{nullptr});
-    CHECK(key_value1.json_value() == "[null]");
+    REQUIRE(key_value1.json_value() == "[null]");
   }
 }
 
@@ -61,55 +61,62 @@ TEST_CASE("hex-integer conversions") {
   char data[16];
 
   SECTION("Verify hex conversion and back against a range of values.") {
-    for (uint64_t x = 0; x < 1000; ++x) {
-      CHECK(x == *HexToUint64(Uint64ToHex(x, data)));
-      auto y = std::numeric_limits<uint64_t>::max() - x;
-      CHECK(y == *HexToUint64(Uint64ToHex(y, data)));
+    for (uint32_t x = 0; x < 1000; ++x) {
+      {
+        REQUIRE(x == *HexToUint64(Uint64ToHex(x, data)));
+        auto y = std::numeric_limits<uint64_t>::max() - x;
+        REQUIRE(y == *HexToUint64(Uint64ToHex(y, data)));
+      }
+      {
+        REQUIRE(x == *HexToUint64(Uint32ToHex(x, data)));
+        auto y = std::numeric_limits<uint32_t>::max() - x;
+        REQUIRE(y == *HexToUint64(Uint64ToHex(y, data)));
+      }
     }
   }
 
   SECTION("Verify a few special values.") {
-    CHECK(Uint64ToHex(0, data) == "0000000000000000");
-    CHECK(Uint64ToHex(1, data) == "0000000000000001");
-    CHECK(Uint64ToHex(std::numeric_limits<uint64_t>::max(), data) ==
-          "FFFFFFFFFFFFFFFF");
+    REQUIRE(Uint64ToHex(0, data) == "0000000000000000");
+    REQUIRE(Uint64ToHex(1, data) == "0000000000000001");
+    REQUIRE(Uint64ToHex(std::numeric_limits<uint64_t>::max(), data) ==
+            "FFFFFFFFFFFFFFFF");
 
-    CHECK(*HexToUint64("0") == 0);
-    CHECK(*HexToUint64("1") == 1);
-    CHECK(*HexToUint64("FFFFFFFFFFFFFFFF") ==
-          std::numeric_limits<uint64_t>::max());
+    REQUIRE(*HexToUint64("0") == 0);
+    REQUIRE(*HexToUint64("1") == 1);
+    REQUIRE(*HexToUint64("FFFFFFFFFFFFFFFF") ==
+            std::numeric_limits<uint64_t>::max());
   }
 
   SECTION("Leading or trailing spaces are ignored when converting from hex.") {
-    CHECK(*HexToUint64("  \tabc") == 0xabc);
-    CHECK(*HexToUint64("abc  \t") == 0xabc);
-    CHECK(*HexToUint64("  \tabc  \t") == 0xabc);
+    REQUIRE(*HexToUint64("  \tabc") == 0xabc);
+    REQUIRE(*HexToUint64("abc  \t") == 0xabc);
+    REQUIRE(*HexToUint64("  \tabc  \t") == 0xabc);
   }
 
   SECTION("Hex conversion works with both upper and lower case digits.") {
-    CHECK(*HexToUint64("ABCDEF") == 0xABCDEF);
-    CHECK(*HexToUint64("abcdef") == 0xABCDEF);
+    REQUIRE(*HexToUint64("ABCDEF") == 0xABCDEF);
+    REQUIRE(*HexToUint64("abcdef") == 0xABCDEF);
   }
 
   SECTION("Hex conversion with an empty string gives an error.") {
-    CHECK(!HexToUint64(""));
-    CHECK(!HexToUint64("  "));
+    REQUIRE(!HexToUint64(""));
+    REQUIRE(!HexToUint64("  "));
   }
 
   SECTION(
       "Hex conversion of a number bigger than "
       "std::numeric_limits<uint64_t>::max() gives an error.") {
-    CHECK(!HexToUint64("1123456789ABCDEF1"));
+    REQUIRE(!HexToUint64("1123456789ABCDEF1"));
   }
 
   SECTION(
       "Hex conversion of a number within valid limits but with leading zeros "
       "past 16 digits is successful.") {
-    CHECK(HexToUint64("0123456789ABCDEF1"));
+    REQUIRE(HexToUint64("0123456789ABCDEF1"));
   }
 
   SECTION("Hex conversion with invalid digits gives an error.") {
-    CHECK(!HexToUint64("abcHef"));
+    REQUIRE(!HexToUint64("abcHef"));
   }
 }
 


### PR DESCRIPTION
snprintf was accounting for a significant portion of tracing cost (~25%). This replaces it with faster code.