### PR TITLE
Add a spin lock

### DIFF
--- a/src/common/BUILD
+++ b/src/common/BUILD
@@ -14,6 +14,13 @@ lightstep_cc_library(
 )
 
 lightstep_cc_library(
+    name = "spin_lock_mutex_lib",
+    private_hdrs = [
+        "spin_lock_mutex.h",
+    ],
+)
+
+lightstep_cc_library(
     name = "direct_coded_output_stream_lib",
     private_hdrs = [
         "direct_coded_output_stream.h",

--- a/src/common/spin_lock_mutex.h
+++ b/src/common/spin_lock_mutex.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+
+namespace lightstep {
+/**
+ * Simple spin lock implementation.
+ *
+ * See https://stackoverflow.com/a/29195378/4447365
+ */
+class SpinLockMutex {
+ public:
+  inline void lock() noexcept {
+    while (locked_.test_and_set(std::memory_order_acquire)) {
+    }
+  }
+
+  inline void unlock() noexcept { locked_.clear(std::memory_order_release); }
+
+ private:
+  std::atomic_flag locked_ = ATOMIC_FLAG_INIT;
+};
+
+using SpinLockGuard = std::lock_guard<SpinLockMutex>;
+}  // namespace lightstep

--- a/src/common/spin_lock_mutex.h
+++ b/src/common/spin_lock_mutex.h
@@ -11,6 +11,7 @@ namespace lightstep {
  */
 class SpinLockMutex {
  public:
+  // std Mutex requirements
   inline void lock() noexcept {
     while (locked_.test_and_set(std::memory_order_acquire)) {
     }

--- a/src/tracer/BUILD
+++ b/src/tracer/BUILD
@@ -82,6 +82,7 @@ lightstep_cc_library(
         "//src/common:utility_lib",
         "//src/common:random_lib",
         "//src/common:serialization_chain_lib",
+        "//src/common:spin_lock_mutex_lib",
         "//src/recorder:recorder_interface",
         "//src/tracer/legacy:legacy_immutable_span_context_lib",
         ":baggage_flat_map_lib",

--- a/src/tracer/span.cpp
+++ b/src/tracer/span.cpp
@@ -82,7 +82,7 @@ Span::~Span() noexcept {
 //------------------------------------------------------------------------------
 void Span::FinishWithOptions(
     const opentracing::FinishSpanOptions& options) noexcept try {
-  std::lock_guard<std::mutex> lock_guard{mutex_};
+  SpinLockGuard lock_guard{mutex_};
   FinishImpl(options);
 } catch (const std::exception& e) {
   tracer_->logger().Error("FinishWithOptions failed: ", e.what());
@@ -92,7 +92,7 @@ void Span::FinishWithOptions(
 // SetOperationName
 //------------------------------------------------------------------------------
 void Span::SetOperationName(opentracing::string_view name) noexcept try {
-  std::lock_guard<std::mutex> lock_guard{mutex_};
+  SpinLockGuard lock_guard{mutex_};
   if (is_finished_) {
     return;
   }
@@ -106,7 +106,7 @@ void Span::SetOperationName(opentracing::string_view name) noexcept try {
 //------------------------------------------------------------------------------
 void Span::SetTag(opentracing::string_view key,
                   const opentracing::Value& value) noexcept try {
-  std::lock_guard<std::mutex> lock_guard{mutex_};
+  SpinLockGuard lock_guard{mutex_};
   if (is_finished_) {
     return;
   }
@@ -123,7 +123,7 @@ void Span::SetTag(opentracing::string_view key,
 //------------------------------------------------------------------------------
 void Span::SetBaggageItem(opentracing::string_view restricted_key,
                           opentracing::string_view value) noexcept try {
-  std::lock_guard<std::mutex> lock_guard{mutex_};
+  SpinLockGuard lock_guard{mutex_};
   if (is_finished_) {
     return;
   }
@@ -137,7 +137,7 @@ void Span::SetBaggageItem(opentracing::string_view restricted_key,
 //------------------------------------------------------------------------------
 std::string Span::BaggageItem(opentracing::string_view restricted_key) const
     noexcept try {
-  std::lock_guard<std::mutex> lock_guard{mutex_};
+  SpinLockGuard lock_guard{mutex_};
   auto iter = baggage_.find(restricted_key);
   if (iter != baggage_.end()) {
     return iter->second;
@@ -156,7 +156,7 @@ void Span::Log(std::initializer_list<
                std::pair<opentracing::string_view, opentracing::Value>>
                    fields) noexcept try {
   auto timestamp = SystemClock::now();
-  std::lock_guard<std::mutex> lock_guard{mutex_};
+  SpinLockGuard lock_guard{mutex_};
   if (is_finished_) {
     return;
   }
@@ -171,7 +171,7 @@ void Span::Log(std::initializer_list<
 void Span::ForeachBaggageItem(
     std::function<bool(const std::string& key, const std::string& value)> f)
     const {
-  std::lock_guard<std::mutex> lock_guard{mutex_};
+  SpinLockGuard lock_guard{mutex_};
   for (const auto& baggage_item : baggage_) {
     if (!f(baggage_item.first, baggage_item.second)) {
       return;
@@ -183,7 +183,7 @@ void Span::ForeachBaggageItem(
 // sampled
 //------------------------------------------------------------------------------
 bool Span::sampled() const noexcept {
-  std::lock_guard<std::mutex> lock_guard{mutex_};
+  SpinLockGuard lock_guard{mutex_};
   return sampled_;
 }
 

--- a/src/tracer/span.h
+++ b/src/tracer/span.h
@@ -6,6 +6,7 @@
 #include <mutex>
 
 #include "common/serialization_chain.h"
+#include "common/spin_lock_mutex.h"
 #include "tracer/baggage_flat_map.h"
 #include "tracer/lightstep_span_context.h"
 #include "tracer/propagation.h"
@@ -83,7 +84,13 @@ class Span final : public opentracing::Span, public LightStepSpanContext {
   uint64_t span_id() const noexcept override { return span_id_; }
 
  private:
-  mutable std::mutex mutex_;
+  // Profiling shows that even with no contention, lock and unlocking a standard
+  // mutex represents a significant portion of the cost of instrumentation.
+  //
+  // Even if there is contention, the span operations are cheap, so it makes
+  // more sense to use a spin lock here.
+  mutable SpinLockMutex mutex_;
+
   std::unique_ptr<SerializationChain> serialization_chain_;
   google::protobuf::io::CodedOutputStream stream_;
 
@@ -99,7 +106,7 @@ class Span final : public opentracing::Span, public LightStepSpanContext {
   template <class Carrier>
   opentracing::expected<void> InjectImpl(
       const PropagationOptions& propagation_options, Carrier& writer) const {
-    std::lock_guard<std::mutex> lock_guard{mutex_};
+    SpinLockGuard lock_guard{mutex_};
     return InjectSpanContext(propagation_options, writer, trace_id_, span_id_,
                              sampled_, baggage_);
   }

--- a/src/tracer/span.h
+++ b/src/tracer/span.h
@@ -84,11 +84,12 @@ class Span final : public opentracing::Span, public LightStepSpanContext {
   uint64_t span_id() const noexcept override { return span_id_; }
 
  private:
-  // Profiling shows that even with no contention, lock and unlocking a standard
-  // mutex represents a significant portion of the cost of instrumentation.
+  // Profiling shows that even with no contention, locking and unlocking a
+  // standard mutex represents a significant portion of the cost of
+  // instrumentation.
   //
   // Even if there is contention, the span operations are cheap, so it makes
-  // more sense to use a spin lock here.
+  // more sense to use a spin lock for this use case.
   mutable SpinLockMutex mutex_;
 
   std::unique_ptr<SerializationChain> serialization_chain_;

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -18,6 +18,17 @@ lightstep_catch_test(
 )
 
 lightstep_catch_test(
+    name = "spin_lock_mute_test",
+    srcs = [
+        "spin_lock_mutex_test.cpp",
+    ],
+    linkopts = ["-pthread"],
+    deps = [
+        "//src/common:spin_lock_mutex_lib",
+    ],
+)
+
+lightstep_catch_test(
     name = "circular_buffer_test",
     srcs = [
         "circular_buffer_test.cpp",

--- a/test/common/spin_lock_mutex_test.cpp
+++ b/test/common/spin_lock_mutex_test.cpp
@@ -1,0 +1,35 @@
+#include "common/spin_lock_mutex.h"
+
+#include <thread>
+
+#include "3rd_party/catch2/catch.hpp"
+using namespace lightstep;
+
+static void AddNumbers(SpinLockMutex& mutex, int a, int b,
+                       std::vector<int>& v) {
+  for (int i = a; i < b; ++i) {
+    SpinLockGuard lock_guard{mutex};
+    v.push_back(i);
+  }
+}
+
+TEST_CASE("SpinLockMutex") {
+  std::vector<int> v;
+  std::vector<std::thread> threads(4);
+  SpinLockMutex mutex;
+  int a = 0;
+  int n = 5000;
+  for (auto& thread : threads) {
+    thread = std::thread{AddNumbers, std::ref(mutex), a, a + n, std::ref(v)};
+    a += n;
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  std::sort(v.begin(), v.end());
+  REQUIRE(v.size() == static_cast<size_t>(n * threads.size()));
+  int index = 0;
+  for (auto value : v) {
+    REQUIRE(value == index++);
+  }
+}


### PR DESCRIPTION
Locking and unlocking an uncontested pthread mutex represents nearly 8% of instrumentation cost: https://5824-57146219-gh.circle-artifacts.com/0/benchmark/span_operations_benchmark-BM_SpanSetTag2-stream.png

This replaces the span's mutex with a more efficient spin lock. New profile: https://5835-57146219-gh.circle-artifacts.com/0/benchmark/span_operations_benchmark-BM_SpanSetTag2-stream.png