### PR TITLE
Fix build for aarch64

### DIFF
--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -51,7 +51,7 @@ timeval ToTimeval(std::chrono::microseconds microseconds) {
 static void WriteEscapedString(std::ostringstream& writer,
                                opentracing::string_view s) {
   writer << '"';
-  for (char c : s) {
+  for (signed char c : s) {
     switch (c) {
       case '"':
         writer << R"(\")";


### PR DESCRIPTION
GCC on aarch64 assumes that `char` is implemented as `unsigned char`
which causes -Werror=type-limits.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>