### PR TITLE
Add Cloud trace support (x-cloud-trace-context header)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(LIGHTSTEP_VERSION_STRING
 # ==============================================================================
 # Set up cpack
 
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY 
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
                   "A LightStep implementation of the C++ OpenTracing API")
 set(CPACK_PACKAGE_VENDOR "lightstep.com")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
@@ -56,13 +56,13 @@ option(WITH_CARES "Build with support for dns resolution using c-ares." OFF)
 option(WITH_DYNAMIC_LOAD "Build support for dynamic loading." ON)
 option(HEADERS_ONLY "Only generate version.h." OFF)
 
-# Allow a user to specify an optional default roots.pem file to embed into the 
-# library. 
+# Allow a user to specify an optional default roots.pem file to embed into the
+# library.
 #
 # This is useful if the library is distributed to an environment where gRPC
 # hasn't been installed.
 #
-# To use, invoke cmake with 
+# To use, invoke cmake with
 #   cmake -DDEFAULT_SSL_ROOTS_PEM:STRING=/path/to/roots.pem ...
 #
 # See also discussion on https://github.com/grpc/grpc/issues/4834
@@ -87,7 +87,7 @@ endif()
 
 configure_file(version.h.in include/lightstep/version.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/lightstep 
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/lightstep
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(HEADERS_ONLY)
@@ -131,12 +131,7 @@ endif()
 include_directories(SYSTEM ${OPENTRACING_INCLUDE_DIR})
 list(APPEND LIGHTSTEP_LINK_LIBRARIES ${OPENTRACING_LIBRARY})
 
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads REQUIRED)
-list(APPEND LIGHTSTEP_LINK_LIBRARIES Threads::Threads)
-
-if (WITH_GRPC)                           
+if (WITH_GRPC)
   find_package(gRPC CONFIG)
   # First attempt to set up gRPC via cmake; but if cmake config files aren't
   # available, fallback to pkg-config.
@@ -154,7 +149,7 @@ if (WITH_GRPC)
     find_package(PkgConfig REQUIRED)
     pkg_search_module(GRPC REQUIRED grpc)
     pkg_search_module(GRPCPP REQUIRED grpc++)
-    list(APPEND LIGHTSTEP_LINK_LIBRARIES ${GRPCPP_LDFLAGS} ${GRPC_LDFLAGS})  
+    list(APPEND LIGHTSTEP_LINK_LIBRARIES ${GRPCPP_LDFLAGS} ${GRPC_LDFLAGS})
     include_directories(SYSTEM ${GRPC_INCLUDE_DIRS} ${GRPCPP_INCLUDE_DIRS})
   endif()
 endif()
@@ -180,7 +175,7 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 list(APPEND LIGHTSTEP_LINK_LIBRARIES Threads::Threads)
 
-if (WIN32) 
+if (WIN32)
   list(APPEND LIGHTSTEP_LINK_LIBRARIES "wsock32" "ws2_32")
 endif()
 
@@ -320,7 +315,7 @@ else()
   list(APPEND LIGHTSTEP_SRCS ${EMBED_SSL_ROOTS_PEM_CPP_FILE})
 endif()
 
-if (BUILD_SHARED_LIBS)  
+if (BUILD_SHARED_LIBS)
   add_library(lightstep_tracer SHARED $<TARGET_OBJECTS:lightstep_tracer_common>
                                       $<TARGET_OBJECTS:lightstep_tracer_configuration>
                                       $<TARGET_OBJECTS:lightstep_3rd_party>
@@ -332,7 +327,7 @@ if (BUILD_SHARED_LIBS)
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-if (BUILD_STATIC_LIBS)  
+if (BUILD_STATIC_LIBS)
   add_library(lightstep_tracer-static STATIC $<TARGET_OBJECTS:lightstep_tracer_common>
                                              $<TARGET_OBJECTS:lightstep_tracer_configuration>
                                              $<TARGET_OBJECTS:lightstep_3rd_party>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(LIGHTSTEP_VERSION_STRING
 # ==============================================================================
 # Set up cpack
 
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY 
                   "A LightStep implementation of the C++ OpenTracing API")
 set(CPACK_PACKAGE_VENDOR "lightstep.com")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
@@ -56,13 +56,13 @@ option(WITH_CARES "Build with support for dns resolution using c-ares." OFF)
 option(WITH_DYNAMIC_LOAD "Build support for dynamic loading." ON)
 option(HEADERS_ONLY "Only generate version.h." OFF)
 
-# Allow a user to specify an optional default roots.pem file to embed into the
-# library.
+# Allow a user to specify an optional default roots.pem file to embed into the 
+# library. 
 #
 # This is useful if the library is distributed to an environment where gRPC
 # hasn't been installed.
 #
-# To use, invoke cmake with
+# To use, invoke cmake with 
 #   cmake -DDEFAULT_SSL_ROOTS_PEM:STRING=/path/to/roots.pem ...
 #
 # See also discussion on https://github.com/grpc/grpc/issues/4834
@@ -87,7 +87,7 @@ endif()
 
 configure_file(version.h.in include/lightstep/version.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/lightstep
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/lightstep 
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(HEADERS_ONLY)
@@ -131,7 +131,7 @@ endif()
 include_directories(SYSTEM ${OPENTRACING_INCLUDE_DIR})
 list(APPEND LIGHTSTEP_LINK_LIBRARIES ${OPENTRACING_LIBRARY})
 
-if (WITH_GRPC)
+if (WITH_GRPC)                           
   find_package(gRPC CONFIG)
   # First attempt to set up gRPC via cmake; but if cmake config files aren't
   # available, fallback to pkg-config.
@@ -149,7 +149,7 @@ if (WITH_GRPC)
     find_package(PkgConfig REQUIRED)
     pkg_search_module(GRPC REQUIRED grpc)
     pkg_search_module(GRPCPP REQUIRED grpc++)
-    list(APPEND LIGHTSTEP_LINK_LIBRARIES ${GRPCPP_LDFLAGS} ${GRPC_LDFLAGS})
+    list(APPEND LIGHTSTEP_LINK_LIBRARIES ${GRPCPP_LDFLAGS} ${GRPC_LDFLAGS})  
     include_directories(SYSTEM ${GRPC_INCLUDE_DIRS} ${GRPCPP_INCLUDE_DIRS})
   endif()
 endif()
@@ -175,7 +175,7 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 list(APPEND LIGHTSTEP_LINK_LIBRARIES Threads::Threads)
 
-if (WIN32)
+if (WIN32) 
   list(APPEND LIGHTSTEP_LINK_LIBRARIES "wsock32" "ws2_32")
 endif()
 
@@ -315,7 +315,7 @@ else()
   list(APPEND LIGHTSTEP_SRCS ${EMBED_SSL_ROOTS_PEM_CPP_FILE})
 endif()
 
-if (BUILD_SHARED_LIBS)
+if (BUILD_SHARED_LIBS)  
   add_library(lightstep_tracer SHARED $<TARGET_OBJECTS:lightstep_tracer_common>
                                       $<TARGET_OBJECTS:lightstep_tracer_configuration>
                                       $<TARGET_OBJECTS:lightstep_3rd_party>
@@ -327,7 +327,7 @@ if (BUILD_SHARED_LIBS)
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-if (BUILD_STATIC_LIBS)
+if (BUILD_STATIC_LIBS)  
   add_library(lightstep_tracer-static STATIC $<TARGET_OBJECTS:lightstep_tracer_common>
                                              $<TARGET_OBJECTS:lightstep_tracer_configuration>
                                              $<TARGET_OBJECTS:lightstep_3rd_party>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,11 @@ endif()
 include_directories(SYSTEM ${OPENTRACING_INCLUDE_DIR})
 list(APPEND LIGHTSTEP_LINK_LIBRARIES ${OPENTRACING_LIBRARY})
 
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+list(APPEND LIGHTSTEP_LINK_LIBRARIES Threads::Threads)
+
 if (WITH_GRPC)                           
   find_package(gRPC CONFIG)
   # First attempt to set up gRPC via cmake; but if cmake config files aren't

--- a/include/lightstep/tracer.h
+++ b/include/lightstep/tracer.h
@@ -26,7 +26,8 @@ enum class PropagationMode {
   lightstep = 1,
   b3 = 2,
   envoy = 3,
-  trace_context = 4
+  trace_context = 4,
+  cloud_trace = 5
 };
 
 // DynamicConfigurationValue is used for configuration values that can

--- a/src/tracer/json_options.cpp
+++ b/src/tracer/json_options.cpp
@@ -47,6 +47,9 @@ static PropagationMode GetPropagationMode(opentracing::string_view s) {
   if (s == "trace_context") {
     return PropagationMode::trace_context;
   }
+  if (s == "cloud_trace") {
+    return PropagationMode::cloud_trace;
+  }
   std::ostringstream oss;
   oss << "invalid propagation mode " << s;
   throw std::runtime_error{oss.str()};

--- a/src/tracer/propagation/BUILD
+++ b/src/tracer/propagation/BUILD
@@ -167,6 +167,7 @@ lightstep_cc_library(
         ":envoy_propagator_lib",
         ":trace_context_propagator_lib",
         ":baggage_propagator_lib",
+        ":cloud_trace_propagator_lib",
     ],
 )
 
@@ -182,5 +183,20 @@ lightstep_cc_library(
         "//src/common:in_memory_stream_lib",
         ":propagation_options_lib",
         ":trace_context_lib",
+    ],
+)
+
+lightstep_cc_library(
+    name = "cloud_trace_propagator_lib",
+    private_hdrs = [
+        "cloud_trace_propagator.h",
+    ],
+    srcs = [
+        "cloud_trace_propagator.cpp",
+    ],
+    deps = [
+      "//3rd_party/base64:base64_lib",
+      ":binary_propagation_lib",
+      ":utility_lib",
     ],
 )

--- a/src/tracer/propagation/cloud_trace_propagator.cpp
+++ b/src/tracer/propagation/cloud_trace_propagator.cpp
@@ -40,7 +40,6 @@ opentracing::expected<bool> CloudTracePropagator::ExtractSpanContext(
                         return std::tolower(a) == std::tolower(b);
                       });
   };
-  bool sampled;
   opentracing::expected<bool> result;
   if (case_sensitive) {
     result = this->ExtractSpanContextImpl(carrier, trace_context,
@@ -51,7 +50,7 @@ opentracing::expected<bool> CloudTracePropagator::ExtractSpanContext(
   if (!result || !*result) {
     return result;
   }
-  trace_context.trace_flags = SetTraceFlag<SampledFlagMask>(0, sampled);
+
   return result;
 }
 

--- a/src/tracer/propagation/cloud_trace_propagator.cpp
+++ b/src/tracer/propagation/cloud_trace_propagator.cpp
@@ -1,0 +1,126 @@
+#include "tracer/propagation/cloud_trace_propagator.h"
+
+#include <lightstep/base64/base64.h>
+
+#include "common/in_memory_stream.h"
+#include "tracer/propagation/binary_propagation.h"
+#include "tracer/propagation/utility.h"
+
+const opentracing::string_view PropagationSingleKey = "x-cloud-trace-context";
+
+namespace lightstep {
+//--------------------------------------------------------------------------------------------------
+// InjectSpanContext
+//--------------------------------------------------------------------------------------------------
+opentracing::expected<void> CloudTracePropagator::InjectSpanContext(
+    const opentracing::TextMapWriter& carrier,
+    const TraceContext& trace_context, opentracing::string_view /*trace_state*/,
+    const BaggageProtobufMap& baggage) const {
+  return this->InjectSpanContextImpl(carrier, trace_context, baggage);
+}
+
+opentracing::expected<void> CloudTracePropagator::InjectSpanContext(
+    const opentracing::TextMapWriter& carrier,
+    const TraceContext& trace_context, opentracing::string_view /*trace_state*/,
+    const BaggageFlatMap& baggage) const {
+  return this->InjectSpanContextImpl(carrier, trace_context, baggage);
+}
+
+//--------------------------------------------------------------------------------------------------
+// ExtractSpanContext
+//--------------------------------------------------------------------------------------------------
+opentracing::expected<bool> CloudTracePropagator::ExtractSpanContext(
+    const opentracing::TextMapReader& carrier, bool case_sensitive,
+    TraceContext& trace_context, std::string& /*trace_state*/,
+    BaggageProtobufMap& baggage) const {
+  auto iequals =
+      [](opentracing::string_view lhs, opentracing::string_view rhs) noexcept {
+    return lhs.length() == rhs.length() &&
+           std::equal(std::begin(lhs), std::end(lhs), std::begin(rhs),
+                      [](char a, char b) {
+                        return std::tolower(a) == std::tolower(b);
+                      });
+  };
+  bool sampled;
+  opentracing::expected<bool> result;
+  if (case_sensitive) {
+    result = ExtractSpanContextImpl(carrier, trace_context.trace_id_high,
+                                    trace_context.trace_id_low,
+                                    trace_context.parent_id, sampled, baggage,
+                                    std::equal_to<opentracing::string_view>{});
+  } else {
+    result = result = ExtractSpanContextImpl(
+        carrier, trace_context.trace_id_high, trace_context.trace_id_low,
+        trace_context.parent_id, sampled, baggage, iequals);
+  }
+  if (!result || !*result) {
+    return result;
+  }
+  trace_context.trace_flags = SetTraceFlag<SampledFlagMask>(0, sampled);
+  return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+// InjectSpanContextImpl
+//--------------------------------------------------------------------------------------------------
+template <class BaggageMap>
+opentracing::expected<void> CloudTracePropagator::InjectSpanContextImpl(
+    const opentracing::TextMapWriter& carrier,
+    const TraceContext& trace_context, const BaggageMap& baggage) const {
+  std::ostringstream ostream;
+  auto result = lightstep::InjectSpanContext(
+      ostream, trace_context.trace_id_low, trace_context.parent_id,
+      IsTraceFlagSet<SampledFlagMask>(trace_context.trace_flags), baggage);
+  if (!result) {
+    return result;
+  }
+  std::string context_value;
+  try {
+    auto binary_encoding = ostream.str();
+    context_value =
+        Base64::encode(binary_encoding.data(), binary_encoding.size());
+  } catch (const std::bad_alloc&) {
+    return opentracing::make_unexpected(
+        std::make_error_code(std::errc::not_enough_memory));
+  }
+
+  result = carrier.Set(PropagationSingleKey, context_value);
+  if (!result) {
+    return result;
+  }
+  return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+// ExtractSpanContextImpl
+//--------------------------------------------------------------------------------------------------
+template <class KeyCompare>
+opentracing::expected<bool> CloudTracePropagator::ExtractSpanContextImpl(
+    const opentracing::TextMapReader& carrier, uint64_t& trace_id_high,
+    uint64_t& trace_id_low, uint64_t& span_id, bool& sampled,
+    BaggageProtobufMap& baggage, const KeyCompare& key_compare) const {
+  trace_id_high = 0;
+  auto value_maybe = LookupKey(carrier, PropagationSingleKey, key_compare);
+  if (!value_maybe) {
+    if (AreErrorsEqual(value_maybe.error(), opentracing::key_not_found_error)) {
+      return false;
+    }
+    return opentracing::make_unexpected(value_maybe.error());
+  }
+  auto value = *value_maybe;
+  std::string base64_decoding;
+  try {
+    base64_decoding = Base64::decode(value.data(), value.size());
+  } catch (const std::bad_alloc&) {
+    return opentracing::make_unexpected(
+        std::make_error_code(std::errc::not_enough_memory));
+  }
+  if (base64_decoding.empty()) {
+    return opentracing::make_unexpected(
+        opentracing::span_context_corrupted_error);
+  }
+  in_memory_stream istream{base64_decoding.data(), base64_decoding.size()};
+  return lightstep::ExtractSpanContext(istream, trace_id_low, span_id, sampled,
+                                       baggage);
+}
+}  // namespace lightstep

--- a/src/tracer/propagation/cloud_trace_propagator.h
+++ b/src/tracer/propagation/cloud_trace_propagator.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "tracer/propagation/propagator.h"
+
+namespace lightstep {
+class CloudTracePropagator final : public Propagator {
+ public:
+  // Propagator
+  opentracing::expected<void> InjectSpanContext(
+      const opentracing::TextMapWriter& carrier,
+      const TraceContext& trace_context, opentracing::string_view trace_state,
+      const BaggageProtobufMap& baggage) const override;
+
+  opentracing::expected<void> InjectSpanContext(
+      const opentracing::TextMapWriter& carrier,
+      const TraceContext& trace_context, opentracing::string_view trace_state,
+      const BaggageFlatMap& baggage) const override;
+
+  opentracing::expected<bool> ExtractSpanContext(
+      const opentracing::TextMapReader& carrier, bool case_sensitive,
+      TraceContext& trace_context, std::string& trace_state,
+      BaggageProtobufMap& baggage) const override;
+
+  private:
+   template <class BaggageMap>
+   opentracing::expected<void> InjectSpanContextImpl(
+       const opentracing::TextMapWriter& carrier,
+       const TraceContext& trace_context, const BaggageMap& baggage) const;
+
+   template <class KeyCompare>
+   opentracing::expected<bool> ExtractSpanContextImpl(
+       const opentracing::TextMapReader& carrier, uint64_t& trace_id_high,
+       uint64_t& trace_id_low, uint64_t& span_id, bool& sampled,
+       BaggageProtobufMap& baggage, const KeyCompare& key_compare) const;
+};
+}  // namespace lightstep

--- a/src/tracer/propagation/cloud_trace_propagator.h
+++ b/src/tracer/propagation/cloud_trace_propagator.h
@@ -22,15 +22,19 @@ class CloudTracePropagator final : public Propagator {
       BaggageProtobufMap& baggage) const override;
 
   private:
-   template <class BaggageMap>
    opentracing::expected<void> InjectSpanContextImpl(
        const opentracing::TextMapWriter& carrier,
-       const TraceContext& trace_context, const BaggageMap& baggage) const;
+       const TraceContext& trace_context) const;
 
    template <class KeyCompare>
    opentracing::expected<bool> ExtractSpanContextImpl(
-       const opentracing::TextMapReader& carrier, uint64_t& trace_id_high,
-       uint64_t& trace_id_low, uint64_t& span_id, bool& sampled,
-       BaggageProtobufMap& baggage, const KeyCompare& key_compare) const;
+       const opentracing::TextMapReader& carrier, TraceContext& trace_context,
+       const KeyCompare& key_compare, BaggageProtobufMap& baggage) const;
+
+   opentracing::expected<void> ParseCloudTrace(
+       opentracing::string_view s, lightstep::TraceContext& trace_context) const noexcept;
+
+   void SerializeCloudTrace(const TraceContext& trace_context,
+                              char* s) const noexcept;
 };
 }  // namespace lightstep

--- a/src/tracer/propagation/propagation_options.cpp
+++ b/src/tracer/propagation/propagation_options.cpp
@@ -7,6 +7,7 @@
 #include "tracer/propagation/envoy_propagator.h"
 #include "tracer/propagation/lightstep_propagator.h"
 #include "tracer/propagation/trace_context_propagator.h"
+#include "tracer/propagation/cloud_trace_propagator.h"
 
 namespace lightstep {
 //--------------------------------------------------------------------------------------------------
@@ -75,6 +76,9 @@ static std::vector<std::unique_ptr<Propagator>> MakePropagators(
         break;
       case PropagationMode::trace_context:
         result.emplace_back(new TraceContextPropagator{});
+        break;
+      case PropagationMode::cloud_trace:
+        result.emplace_back(new CloudTracePropagator{});
         break;
     }
   }

--- a/test/tracer/propagation/BUILD
+++ b/test/tracer/propagation/BUILD
@@ -141,3 +141,17 @@ lightstep_catch_test(
         "//src/tracer/propagation:propagation_lib",
     ],
 )
+
+lightstep_catch_test(
+    name = "cloud_trace_propagation_test",
+    srcs = [
+        "cloud_trace_propagation_test.cpp",
+    ],
+    deps = [
+        "//:manual_tracer_lib",
+        "//test/recorder:in_memory_recorder_lib",
+        ":text_map_carrier_lib",
+        ":http_headers_carrier_lib",
+        ":utility_lib",
+    ],
+)

--- a/test/tracer/propagation/cloud_trace_propagation_test.cpp
+++ b/test/tracer/propagation/cloud_trace_propagation_test.cpp
@@ -1,0 +1,86 @@
+#include <algorithm>
+
+#include "test/recorder/in_memory_recorder.h"
+#include "test/tracer/propagation/http_headers_carrier.h"
+#include "test/tracer/propagation/text_map_carrier.h"
+#include "test/tracer/propagation/utility.h"
+#include "tracer/legacy/legacy_tracer_impl.h"
+#include "tracer/tracer_impl.h"
+
+#include "3rd_party/catch2/catch.hpp"
+using namespace lightstep;
+
+TEST_CASE("cloud_trace propagation") {
+  LightStepTracerOptions tracer_options;
+  tracer_options.propagation_modes = {PropagationMode::cloud_trace};
+  auto recorder = new InMemoryRecorder{};
+  auto tracer = std::shared_ptr<opentracing::Tracer>{
+      new TracerImpl{MakePropagationOptions(tracer_options),
+                     std::unique_ptr<Recorder>{recorder}}};
+  std::unordered_map<std::string, std::string> text_map;
+  TextMapCarrier text_map_carrier{text_map};
+  HTTPHeadersCarrier http_headers_carrier{text_map};
+
+  SECTION("Inject, extract yields the same span context.") {
+    for (auto use_128bit_trace_ids : {true, false}) {
+      auto test_span_contexts = MakeTestSpanContexts(use_128bit_trace_ids);
+      for (auto& span_context : test_span_contexts) {
+        // text map carrier
+        CHECK_NOTHROW(
+            VerifyInjectExtract(*tracer, *span_context, text_map_carrier));
+        text_map.clear();
+
+        // http headers carrier
+        CHECK_NOTHROW(
+            VerifyInjectExtract(*tracer, *span_context, http_headers_carrier));
+        text_map.clear();
+      }
+    }
+  }
+
+  SECTION("Verify extraction against a 128-bit trace id") {
+    text_map = {{"x-cloud-trace-context", "aef5705a090040838f1359ebafa5c0c6/aef5705a09004083;o=1"}};
+    auto span_context_maybe = tracer->Extract(http_headers_carrier);
+    REQUIRE(span_context_maybe);
+    auto span_context =
+        dynamic_cast<LightStepSpanContext*>(span_context_maybe->get());
+    REQUIRE(span_context->trace_id_high() == 0xaef5705a09004083ul);
+    REQUIRE(span_context->trace_id_low() == 0x8f1359ebafa5c0c6ul);
+    REQUIRE(span_context->span_id() == 0xaef5705a09004083ul);
+    REQUIRE(span_context->sampled() == true);
+  }
+
+  SECTION("Verify extraction with a 128 bit trace id when sampled is false") {
+    text_map = {{"x-cloud-trace-context", "aef5705a090040838f1359ebafa5c0c6/aef5705a09004083;o=0"}};
+    auto span_context_maybe = tracer->Extract(http_headers_carrier);
+    REQUIRE(span_context_maybe);
+    auto span_context =
+        dynamic_cast<LightStepSpanContext*>(span_context_maybe->get());
+    REQUIRE(span_context->trace_id_high() == 0xaef5705a09004083ul);
+    REQUIRE(span_context->trace_id_low() == 0x8f1359ebafa5c0c6ul);
+    REQUIRE(span_context->span_id() == 0xaef5705a09004083ul);
+    REQUIRE(span_context->sampled() == false);
+  }
+
+  SECTION("A child keeps the same trace id as its parent") {
+    text_map = {{"x-cloud-trace-context", "aef5705a090040838f1359ebafa5c0c6/aef5705a09004083;o=0"}};
+    auto span_context_maybe = tracer->Extract(http_headers_carrier);
+    REQUIRE(span_context_maybe);
+    auto span = tracer->StartSpan(
+        "abc", {opentracing::ChildOf(span_context_maybe->get())});
+    auto span_context1 =
+        dynamic_cast<LightStepSpanContext*>(span_context_maybe->get());
+    auto span_context2 =
+        dynamic_cast<const LightStepSpanContext*>(&span->context());
+    REQUIRE(span_context1->trace_id_high() == span_context2->trace_id_high());
+    REQUIRE(span_context1->trace_id_low() == span_context2->trace_id_low());
+  }
+
+  SECTION("The low part of 128-bit trace ids are sent to satellites") {
+    text_map = {{"x-cloud-trace-context", "aef5705a090040838f1359ebafa5c0c6/aef5705a09004083;o=1"}};
+    auto span_context_maybe = tracer->Extract(http_headers_carrier);
+    REQUIRE(span_context_maybe);
+    tracer->StartSpan("abc", {opentracing::ChildOf(span_context_maybe->get())});
+    REQUIRE(recorder->top().span_context().trace_id() == 0x8f1359ebafa5c0c6ul);
+  }
+}


### PR DESCRIPTION
Adds support for Google's `x-cloud-trace-context` header.

*TODO* Verify what the behaviour of Span ID should be when only a trace ID is given